### PR TITLE
Localsplus and details

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ This debugger extension provides visualizations for Python objects and stacktrac
 
 The goal of this project is to provide a similar debugging experience in WinDbg/CDB/NTSD as `already exists in GDB <https://wiki.python.org/moin/DebuggingWithGdb>`_.
 
-Currently, the extension is tested against 32bit and 64bit builds of Python versions 2.7, 3.3, 3.4, 3.5, and 3.6.
+Currently, the extension is tested against 32bit and 64bit builds of Python versions 2.7, 3.3, 3.4, 3.5, 3.6, 3.7 and 3.8.
 
 Installation
 ============

--- a/include/PyCellObject.h
+++ b/include/PyCellObject.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "PyObject.h"
+#include <string>
+
+namespace PyExt::Remote {
+
+	/// Represents a PyBoolObject in the debuggee's address space.
+	class PYEXT_PUBLIC PyCellObject : public PyObject
+	{
+
+	public: // Construction/Destruction.
+		explicit PyCellObject(Offset objectAddress);
+
+	public: // Members.
+		auto objectReference() const -> std::unique_ptr<PyObject>;
+		auto repr(bool pretty = true) const -> std::string override;
+
+	};
+
+}

--- a/include/PyCodeObject.h
+++ b/include/PyCodeObject.h
@@ -14,9 +14,12 @@ namespace PyExt::Remote {
 	public: // Construction/Destruction.
 		explicit PyCodeObject(Offset objectAddress);
 
-	public: // Members.
+	public:
+		// Members.
+		auto numberOfLocals() const -> int;
 		auto firstLineNumber() const -> int;
 		auto lineNumberFromInstructionOffset(int instruction) const -> int;
+		auto varNames() const->std::vector<std::string>;
 		auto filename() const -> std::string;
 		auto name() const -> std::string;
 		auto lineNumberTable() const -> std::vector<std::uint8_t>;

--- a/include/PyCodeObject.h
+++ b/include/PyCodeObject.h
@@ -20,11 +20,16 @@ namespace PyExt::Remote {
 		auto firstLineNumber() const -> int;
 		auto lineNumberFromInstructionOffset(int instruction) const -> int;
 		auto varNames() const->std::vector<std::string>;
+		auto freeVars() const->std::vector<std::string>;
+		auto cellVars() const->std::vector<std::string>;
 		auto filename() const -> std::string;
 		auto name() const -> std::string;
 		auto lineNumberTable() const -> std::vector<std::uint8_t>;
 		auto repr(bool pretty = true) const -> std::string override;
 
+	protected:
+		// Helpers.
+		auto readStringTuple(std::string name) const -> std::vector<std::string>;
 	};
 
 }

--- a/include/PyFrameObject.h
+++ b/include/PyFrameObject.h
@@ -20,6 +20,7 @@ namespace PyExt::Remote {
 
 	public: // Members.
 		auto locals() const -> std::unique_ptr<PyDictObject>;
+		auto localsplus() const -> std::vector<std::pair<std::string, std::unique_ptr<PyObject>>>;
 		auto globals() const -> std::unique_ptr<PyDictObject>;
 		auto builtins() const -> std::unique_ptr<PyDictObject>;
 		auto code() const -> std::unique_ptr<PyCodeObject>;
@@ -28,6 +29,7 @@ namespace PyExt::Remote {
 		auto lastInstruction() const -> int;
 		auto currentLineNumber() const -> int;
 		auto repr(bool pretty = true) const -> std::string override;
+		auto details() const -> std::string override;
 
 	};
 

--- a/include/PyMemberDef.h
+++ b/include/PyMemberDef.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "RemoteType.h"
+#include "pyextpublic.h"
+
+namespace PyExt::Remote {
+
+	class PYEXT_PUBLIC PyMemberDef : private RemoteType
+	{
+
+	public: // Constants.
+		static const int T_SHORT          =  0;
+		static const int T_INT            =  1;
+		static const int T_LONG           =  2;
+		static const int T_FLOAT          =  3;
+		static const int T_DOUBLE         =  4;
+		static const int T_STRING         =  5;
+		static const int T_OBJECT         =  6;
+		static const int T_CHAR           =  7;
+		static const int T_BYTE           =  8;
+		static const int T_UBYTE          =  9;
+		static const int T_USHORT         = 10;
+		static const int T_UINT           = 11;
+		static const int T_ULONG          = 12;
+		static const int T_STRING_INPLACE = 13;
+		static const int T_BOOL           = 14;
+		static const int T_OBJECT_EX      = 16;
+		static const int T_LONGLONG       = 17;
+		static const int T_ULONGLONG      = 18;
+		static const int T_PYSSIZET       = 19;
+		static const int T_NONE           = 20;
+
+	public: // Construction/Destruction.
+		explicit PyMemberDef(Offset objectAddress);
+		~PyMemberDef();
+
+	public: // Members of the remote type.
+		auto name() const -> std::string;
+		auto type() const -> int;
+		auto offset() const -> SSize;
+
+	};
+
+}

--- a/include/PyObject.h
+++ b/include/PyObject.h
@@ -27,8 +27,10 @@ namespace PyExt::Remote {
 		explicit PyObject(Offset objectAddress, const std::string& symbolName = "PyObject");
 		virtual ~PyObject();
 
-		/// Polymorphic constructor. Creates the most-derived PyObject it can.
+		// Polymorphic constructor. Creates the most-derived PyObject it can.
 		static auto make(PyObject::Offset remoteAddress) -> std::unique_ptr<PyObject>;
+		// Constructor by type name. Necessary to get the base type repr for types derived from built-in types.
+		static auto make(PyObject::Offset remoteAddress, const std::string& typeName) -> std::unique_ptr<PyObject>;
 
 	public: // Members.
 		using RemoteType::offset;

--- a/include/PyObject.h
+++ b/include/PyObject.h
@@ -13,6 +13,7 @@ class ExtRemoteTyped;
 namespace PyExt::Remote {
 
 	class PyTypeObject; //< Forward Declaration.
+	class PyDictObject; //< Forward Declaration.
 
 	/// Represents a PyObject in the debuggee's address space. Base class for all types of PyObject.
 	class PYEXT_PUBLIC PyObject : private RemoteType
@@ -20,7 +21,7 @@ namespace PyExt::Remote {
 
 	public: // Typedefs.
 		using RemoteType::Offset;
-		using SSize = std::int64_t;
+		using RemoteType::SSize;
 
 	public: // Construction/Destruction.
 		explicit PyObject(Offset objectAddress, const std::string& symbolName = "PyObject");
@@ -34,7 +35,10 @@ namespace PyExt::Remote {
 		using RemoteType::symbolName;
 		auto refCount() const -> SSize;
 		auto type() const -> PyTypeObject;
+		auto slots() const -> std::vector<std::pair<std::string, std::unique_ptr<PyObject>>>;
+		auto dict() const -> std::unique_ptr<PyDictObject>;
 		virtual auto repr(bool pretty = true) const -> std::string;
+		virtual auto details() const -> std::string;
 
 	protected: // Helpers for more derived classes.
 		/// Returns a field by name in the `ob_base` member.

--- a/include/PyObject.h
+++ b/include/PyObject.h
@@ -31,6 +31,7 @@ namespace PyExt::Remote {
 		static auto make(PyObject::Offset remoteAddress) -> std::unique_ptr<PyObject>;
 		// Constructor by type name. Necessary to get the base type repr for types derived from built-in types.
 		static auto make(PyObject::Offset remoteAddress, const std::string& typeName) -> std::unique_ptr<PyObject>;
+		using RemoteType::readOffsetArray;
 
 	public: // Members.
 		using RemoteType::offset;

--- a/include/PyStringObject.h
+++ b/include/PyStringObject.h
@@ -16,7 +16,7 @@ namespace PyExt::Remote {
 	public: // Members.
 		auto stringLength() const -> SSize;
 		auto stringValue() const -> std::string override;
-		auto repr(bool pretty = true) const -> std::string override;
+		virtual auto repr(bool pretty = true) const -> std::string override;
 
 	};
 
@@ -27,6 +27,7 @@ namespace PyExt::Remote {
 	class PYEXT_PUBLIC PyBytesObject : public PyBaseStringObject {
 	public:
 		explicit PyBytesObject(Offset objectAddress);
+		auto repr(bool pretty = true) const -> std::string override;
 	};
 
 

--- a/include/PyTypeObject.h
+++ b/include/PyTypeObject.h
@@ -16,6 +16,8 @@ namespace PyExt::Remote {
 
 	public: // Members.
 		auto name() const -> std::string;
+		auto basicSize() const -> SSize;
+		auto itemSize() const->SSize;
 		auto documentation() const -> std::string;
 		auto members() const -> std::vector<std::unique_ptr<PyMemberDef>>;
 		auto dictOffset() const -> SSize;

--- a/include/PyTypeObject.h
+++ b/include/PyTypeObject.h
@@ -3,6 +3,7 @@
 #include "PyVarObject.h"
 #include "PyMemberDef.h"
 #include "PyTupleObject.h"
+#include <array>
 #include <string>
 
 namespace PyExt::Remote {
@@ -10,6 +11,27 @@ namespace PyExt::Remote {
 	/// Represents a PyTypeObject in the debuggee's address space.
 	class PYEXT_PUBLIC PyTypeObject : public PyVarObject
 	{
+	public:
+		static const inline std::array builtinTypes{
+			"type",
+			"str",
+			"bytes",
+			"bytearray",
+			"tuple",
+			"set",
+			"dict",
+			"int",
+			"long",
+			"float",
+			"bool",
+			"complex",
+			"frame",
+			"code",
+			"function",
+			"cell",
+			"NoneType",
+			"NotImplementedType",
+		};
 
 	public: // Construction/Destruction.
 		explicit PyTypeObject(Offset objectAddress);

--- a/include/PyTypeObject.h
+++ b/include/PyTypeObject.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "PyVarObject.h"
+#include "PyMemberDef.h"
+#include "PyTupleObject.h"
 #include <string>
 
 namespace PyExt::Remote {
@@ -15,6 +17,9 @@ namespace PyExt::Remote {
 	public: // Members.
 		auto name() const -> std::string;
 		auto documentation() const -> std::string;
+		auto members() const -> std::vector<std::unique_ptr<PyMemberDef>>;
+		auto dictOffset() const -> SSize;
+		auto mro() const -> std::unique_ptr<PyTupleObject>;
 		auto isPython2() const -> bool;
 		auto repr(bool pretty = true) const -> std::string override;
 

--- a/include/RemoteType.h
+++ b/include/RemoteType.h
@@ -32,6 +32,8 @@ namespace PyExt::Remote {
 	public: // Methods.
 		auto offset() const -> Offset;
 		auto symbolName() const -> std::string;
+		// necessary for x86 because offsets in remote address space are only 32 Bit
+		static auto readOffsetArray(/*const*/ ExtRemoteTyped& remoteArray, unsigned long numElements) -> std::vector<Offset>;
 
 	protected: // Helpers for more derived classes.
 		/// Access to the instance's memory in the debuggee.

--- a/include/RemoteType.h
+++ b/include/RemoteType.h
@@ -17,6 +17,7 @@ namespace PyExt::Remote {
 
 	public: // Typedefs.
 		using Offset = std::uint64_t;
+		using SSize = std::int64_t;
 
 	public: // Construction/Destruction.
 		explicit RemoteType(Offset objectAddress, const std::string& symbolName);

--- a/include/utils/ScopeExit.h
+++ b/include/utils/ScopeExit.h
@@ -27,7 +27,7 @@ namespace utils {
 			other.reset();
 		};
 
-		ScopeExit& operator=(ScopeExit&&)
+		ScopeExit& operator=(ScopeExit&& other)
 		{
 			f_ = std::move(other.f_);
 			other.reset();

--- a/src/ExtHelpers.cpp
+++ b/src/ExtHelpers.cpp
@@ -1,0 +1,38 @@
+#include "ExtHelpers.h"
+
+#include <string>
+#include <sstream>
+using namespace std;
+
+
+namespace utils {
+
+	auto escapeDml(const string& str) -> string
+	{
+		std::string buffer;
+		buffer.reserve(str.size());
+		for (auto ch : str) {
+			switch (ch) {
+			case '&':  buffer += "&amp;";  break;
+			case '\"': buffer += "&quot;"; break;
+			// case '\'': buffer += "&apos;"; break; no DML special character?!
+			case '<':  buffer += "&lt;";   break;
+			case '>':  buffer += "&gt;";   break;
+			default:   buffer += ch;       break;
+			}
+		}
+		return buffer;
+	}
+
+
+	auto link(const string& text, const string& cmd, const string& alt) -> string
+	{
+		ostringstream oss;
+		oss << "<link cmd=\"" << escapeDml(cmd) << "\"";
+		if (!alt.empty())
+			oss << " alt=\"" << escapeDml(alt) << "\"";
+		oss << ">" << escapeDml(text) << "</link>";
+		return oss.str();
+	}
+
+}

--- a/src/ExtHelpers.cpp
+++ b/src/ExtHelpers.cpp
@@ -7,6 +7,14 @@ using namespace std;
 
 namespace utils {
 
+	auto getPointerSize() -> uint64_t
+	{
+		string objExpression = "sizeof(void*)"s;
+		ExtRemoteTyped remoteObj(objExpression.c_str());
+		return utils::readIntegral<uint64_t>(remoteObj);
+	}
+
+
 	auto escapeDml(const string& str) -> string
 	{
 		std::string buffer;

--- a/src/ExtHelpers.h
+++ b/src/ExtHelpers.h
@@ -3,6 +3,7 @@
 #include <engextcpp.hpp>
 #include <type_traits>
 #include <vector>
+using namespace std::literals::string_literals;
 
 namespace utils {
 
@@ -42,4 +43,9 @@ namespace utils {
 		remoteData.ReadBuffer(buffer.data(), numElements*remoteSize);
 		return buffer;
 	}
+
+
+	auto escapeDml(const std::string& str)->std::string;
+	auto link(const std::string& text, const std::string& cmd, const std::string& alt = ""s) -> std::string;
+
 }

--- a/src/ExtHelpers.h
+++ b/src/ExtHelpers.h
@@ -15,13 +15,13 @@ namespace utils {
 		auto size = remoteData.GetTypeSize();
 		switch (size) {
 		case 1:
-			return static_cast<Integral>(isSigned ? remoteData.GetChar() : remoteData.GetUchar());
+			return isSigned ? static_cast<Integral>(remoteData.GetChar()) : static_cast<Integral>(remoteData.GetUchar());
 		case 2:
-			return static_cast<Integral>(isSigned ? remoteData.GetShort() : remoteData.GetUshort());
+			return isSigned ? static_cast<Integral>(remoteData.GetShort()) : static_cast<Integral>(remoteData.GetUshort());
 		case 4:
-			return static_cast<Integral>(isSigned ? remoteData.GetLong() : remoteData.GetUlong());
+			return isSigned ? static_cast<Integral>(remoteData.GetLong()) : static_cast<Integral>(remoteData.GetUlong());
 		case 8:
-			return static_cast<Integral>(isSigned ? remoteData.GetLong64() : remoteData.GetUlong64());
+			return isSigned ? static_cast<Integral>(remoteData.GetLong64()) : static_cast<Integral>(remoteData.GetUlong64());
 		}
 
 		g_Ext->ThrowInterrupt();
@@ -44,8 +44,8 @@ namespace utils {
 		return buffer;
 	}
 
-
-	auto escapeDml(const std::string& str)->std::string;
+	auto getPointerSize() -> std::uint64_t;
+	auto escapeDml(const std::string& str) -> std::string;
 	auto link(const std::string& text, const std::string& cmd, const std::string& alt = ""s) -> std::string;
 
 }

--- a/src/PyExt.vcxproj
+++ b/src/PyExt.vcxproj
@@ -22,7 +22,7 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{EEBC73BA-27F2-4483-8639-54A108B77594}</ProjectGuid>
     <RootNamespace>PyExt</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -62,7 +62,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <ForcedIncludeFiles>pch.h</ForcedIncludeFiles>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <PreprocessorDefinitions>PYEXT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
@@ -92,6 +92,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="extension.cpp" />
+    <ClCompile Include="ExtHelpers.cpp" />
     <ClCompile Include="objects\PySetObject.cpp" />
     <ClCompile Include="objects\PyStringValue.cpp" />
     <ClCompile Include="objects\PyBoolObject.cpp" />
@@ -119,6 +120,7 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="PyInterpreterState.cpp" />
+    <ClCompile Include="PyMemberDef.cpp" />
     <ClCompile Include="pystack.cpp" />
     <ClCompile Include="pysymfix.cpp" />
     <ClCompile Include="PyThreadState.cpp" />
@@ -137,6 +139,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\PyInterpreterState.h" />
+    <ClInclude Include="..\include\PyMemberDef.h" />
     <ClInclude Include="..\include\PySetObject.h" />
     <ClInclude Include="..\include\PyThreadState.h" />
     <ClInclude Include="..\include\RemoteType.h" />

--- a/src/PyExt.vcxproj
+++ b/src/PyExt.vcxproj
@@ -93,6 +93,7 @@
   <ItemGroup>
     <ClCompile Include="extension.cpp" />
     <ClCompile Include="ExtHelpers.cpp" />
+    <ClCompile Include="objects\PyCellObject.cpp" />
     <ClCompile Include="objects\PySetObject.cpp" />
     <ClCompile Include="objects\PyStringValue.cpp" />
     <ClCompile Include="objects\PyBoolObject.cpp" />
@@ -138,6 +139,7 @@
     <ResourceCompile Include="$(ProjectName).rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\include\PyCellObject.h" />
     <ClInclude Include="..\include\PyInterpreterState.h" />
     <ClInclude Include="..\include\PyMemberDef.h" />
     <ClInclude Include="..\include\PySetObject.h" />

--- a/src/PyExt.vcxproj.filters
+++ b/src/PyExt.vcxproj.filters
@@ -120,6 +120,9 @@
     <ClCompile Include="PyMemberDef.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="objects\PyCellObject.cpp">
+      <Filter>Source Files\objects</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="extension.h">
@@ -220,6 +223,9 @@
     </ClInclude>
     <ClInclude Include="..\include\PyMemberDef.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\PyCellObject.h">
+      <Filter>Header Files\objects</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/PyExt.vcxproj.filters
+++ b/src/PyExt.vcxproj.filters
@@ -114,6 +114,12 @@
     <ClCompile Include="pysymfix.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ExtHelpers.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="PyMemberDef.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="extension.h">
@@ -212,9 +218,12 @@
     <ClInclude Include="..\include\PySetObject.h">
       <Filter>Header Files\objects</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\PyMemberDef.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include=".rc">
+    <ResourceCompile Include="$(ProjectName).rc">
       <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>

--- a/src/PyMemberDef.cpp
+++ b/src/PyMemberDef.cpp
@@ -1,0 +1,41 @@
+#include "PyMemberDef.h"
+
+#include "ExtHelpers.h"
+
+using namespace std;
+
+namespace PyExt::Remote {
+
+	PyMemberDef::PyMemberDef(Offset objectAddress)
+		: RemoteType(objectAddress, "PyMemberDef")
+	{
+	}
+
+
+	PyMemberDef::~PyMemberDef()
+	{
+	}
+
+
+	auto PyMemberDef::name() const -> string
+	{
+		ExtBuffer<char> buff;
+		remoteType().Field("name").Dereference().GetString(&buff);
+		return buff.GetBuffer();
+	}
+
+
+	auto PyMemberDef::type() const -> int
+	{
+		auto type_ = remoteType().Field("type");
+		return utils::readIntegral<int>(type_);
+	}
+
+
+	auto PyMemberDef::offset() const -> SSize
+	{
+		auto offset_ = remoteType().Field("offset");
+		return utils::readIntegral<SSize>(offset_);
+	}
+
+}

--- a/src/RemoteType.cpp
+++ b/src/RemoteType.cpp
@@ -1,5 +1,6 @@
 #include "RemoteType.h"
 
+#include "ExtHelpers.h"
 #include <engextcpp.hpp>
 
 #include <string>
@@ -38,4 +39,25 @@ namespace PyExt::Remote {
 	{
 		return *remoteType_;
 	}
+
+
+	auto RemoteType::readOffsetArray(/*const*/ ExtRemoteTyped& remoteArray, unsigned long numElements) -> vector<Offset>
+	{
+		auto ptrSize = utils::getPointerSize();
+		switch (ptrSize) {
+		case 4: {
+			// x86 - 32 Bit Python
+			auto ptrs = utils::readArray<std::uint32_t>(remoteArray, numElements);
+			vector<Offset> offsets(begin(ptrs), end(ptrs));
+			return offsets;
+		}
+		case 8:
+			// x64 - 64 Bit Python
+			return utils::readArray<Offset>(remoteArray, numElements);
+		}
+
+		g_Ext->ThrowInterrupt();
+		g_Ext->ThrowRemote(E_INVALIDARG, "Unsupported pointer size.");
+	}
+
 }

--- a/src/extension.cpp
+++ b/src/extension.cpp
@@ -79,7 +79,11 @@ namespace PyExt {
 
 		auto repr = pyObj->repr(true);
 		if (!repr.empty())
-			Out("\tRepr: %s\n", repr.c_str());
+			Dml("\tRepr: %s\n", repr.c_str());
+
+		auto details = pyObj->details();
+		if (!details.empty())
+			Dml("\tDetails:\n%s\n", details.c_str());
 	}
 
 

--- a/src/objects/PyByteArrayObject.cpp
+++ b/src/objects/PyByteArrayObject.cpp
@@ -2,6 +2,7 @@
 #include "PyStringValue.h"
 
 #include "utils/lossless_cast.h"
+#include "../ExtHelpers.h"
 
 #include <engextcpp.hpp>
 
@@ -46,9 +47,10 @@ namespace PyExt::Remote {
 	}
 
 
-	auto PyByteArrayObject::repr(bool /*pretty*/) const -> string
+	auto PyByteArrayObject::repr(bool pretty) const -> string
 	{
-		return "bytearray(b"s + escapeAndQuoteString(stringValue()) + ")"s;
+		string repr = "bytearray(b"s + escapeAndQuoteString(stringValue()) + ")"s;
+		return pretty ? utils::escapeDml(repr) : repr;
 	}
 
 }

--- a/src/objects/PyCellObject.cpp
+++ b/src/objects/PyCellObject.cpp
@@ -1,0 +1,32 @@
+#include "PyCellObject.h"
+
+#include "PyTypeObject.h"
+
+#include "../ExtHelpers.h"
+
+#include <string>
+using namespace std;
+
+
+namespace PyExt::Remote {
+
+	PyCellObject::PyCellObject(Offset objectAddress)
+		: PyObject(objectAddress, "PyCellObject")
+	{
+	}
+
+
+	auto PyCellObject::objectReference() const -> unique_ptr<PyObject>
+	{
+		auto objPtr = remoteType().Field("ob_ref").GetPtr();
+		return make(objPtr);
+	}
+
+
+	auto PyCellObject::repr(bool pretty) const -> string
+	{
+		string repr = PyObject::repr(pretty);
+		return repr + ": " + objectReference()->repr(pretty);
+	}
+
+}

--- a/src/objects/PyCodeObject.cpp
+++ b/src/objects/PyCodeObject.cpp
@@ -73,19 +73,19 @@ namespace PyExt::Remote {
 
 	auto PyCodeObject::varNames() const -> vector<string>
 	{
-		auto varNames = utils::fieldAsPyObject<PyTupleObject>(remoteType(), "co_varnames");
-		if (varNames == nullptr)
-			return { };
+		return readStringTuple("co_varnames");
+	}
 
-		auto count = utils::lossless_cast<size_t>(varNames->numItems());
-		vector<string> values(count);
 
-		for (size_t i = 0; i < count; ++i) {
-			auto pyVarName = varNames->at(i);
-			values[i] = pyVarName->repr();
-		}
+	auto PyCodeObject::freeVars() const -> vector<string>
+	{
+		return readStringTuple("co_freevars");
+	}
 
-		return values;
+
+	auto PyCodeObject::cellVars() const -> vector<string>
+	{
+		return readStringTuple("co_cellvars");
 	}
 
 
@@ -128,4 +128,21 @@ namespace PyExt::Remote {
 		return repr;
 	}
 
+
+	auto PyCodeObject::readStringTuple(string name) const -> vector<string>
+	{
+		auto tuplePtr = utils::fieldAsPyObject<PyTupleObject>(remoteType(), name);
+		if (tuplePtr == nullptr)
+			return { };
+
+		auto count = utils::lossless_cast<size_t>(tuplePtr->numItems());
+		vector<string> values(count);
+
+		for (size_t i = 0; i < count; ++i) {
+			auto pyVarName = tuplePtr->at(i);
+			values[i] = pyVarName->repr();
+		}
+
+		return values;
+	}
 }

--- a/src/objects/PyDictObject.cpp
+++ b/src/objects/PyDictObject.cpp
@@ -146,7 +146,7 @@ namespace PyExt::Remote {
 			oss << indentation << key->repr(pretty) << ": " << value->repr(pretty) << ',' << elementSeparator;
 		}
 
-		oss << elementSeparator << '}';
+		oss << '}';
 		return oss.str();
 	}
 

--- a/src/objects/PyFrameObject.cpp
+++ b/src/objects/PyFrameObject.cpp
@@ -47,7 +47,7 @@ namespace PyExt::Remote {
 		names.insert(names.end(), freeVars.begin(), freeVars.end());
 
 		auto f_localsplus = remoteType().Field("f_localsplus");
-		auto pyObjAddrs = utils::readArray<PyObject::Offset>(f_localsplus, numLocalsplus);
+		auto pyObjAddrs = readOffsetArray(f_localsplus, numLocalsplus);
 		vector<pair<string, unique_ptr<PyObject>>> localsplus(numLocalsplus);
 		for (size_t i = 0; i < numLocalsplus; ++i) {
 			auto addr = pyObjAddrs.at(i);

--- a/src/objects/PyFrameObject.cpp
+++ b/src/objects/PyFrameObject.cpp
@@ -51,7 +51,7 @@ namespace PyExt::Remote {
 		vector<pair<string, unique_ptr<PyObject>>> localsplus(numLocalsplus);
 		for (size_t i = 0; i < numLocalsplus; ++i) {
 			auto addr = pyObjAddrs.at(i);
-			auto objPtr = PyObject::make(addr);
+			auto objPtr = addr ? make(addr) : nullptr;
 			localsplus[i] = make_pair(names.at(i), move(objPtr));
 		}
 		return localsplus;
@@ -129,7 +129,8 @@ namespace PyExt::Remote {
 		for (auto const& pairValue : localsplus()) {
 			auto const& key = pairValue.first;
 			auto const& value = pairValue.second;
-			oss << indentation << key << ": " << value->repr(true) << ',' << elementSeparator;
+			if (value != nullptr)
+				oss << indentation << key << ": " << value->repr(true) << ',' << elementSeparator;
 		}
 
 		oss << '}';

--- a/src/objects/PyFunctionObject.cpp
+++ b/src/objects/PyFunctionObject.cpp
@@ -7,6 +7,7 @@
 #include "PyListObject.h"
 #include "PyStringValue.h"
 #include "../fieldAsPyObject.h"
+#include "../ExtHelpers.h"
 
 #include <engextcpp.hpp>
 
@@ -94,13 +95,17 @@ namespace PyExt::Remote {
 	}
 
 
-	auto PyFunctionObject::repr(bool /*pretty*/) const -> string
+	auto PyFunctionObject::repr(bool pretty) const -> string
 	{
 		auto nameObject = name();
+		string repr;
 		if (nameObject == nullptr)
-			return "<function>";
-
-		return "<function " + nameObject->stringValue() + ">";
+			repr = "<function>";
+		else
+			repr = "<function " + nameObject->stringValue() + ">";
+		if (pretty)
+			return utils::link(repr, "!pyobj 0n"s + to_string(offset()));
+		return repr;
 	}
 
 }

--- a/src/objects/PyListObject.cpp
+++ b/src/objects/PyListObject.cpp
@@ -50,7 +50,7 @@ namespace PyExt::Remote {
 	}
 
 
-	auto PyListObject::repr(bool /*pretty*/) const -> string
+	auto PyListObject::repr(bool pretty) const -> string
 	{
 		ostringstream oss;
 		oss << "[ ";
@@ -59,7 +59,7 @@ namespace PyExt::Remote {
 		for (SSize i = 0; i < count; ++i) {
 			auto elem = at(i);
 			if (elem != nullptr)
-				oss << elem->repr();
+				oss << elem->repr(pretty);
 
 			if (i + 1 < count)
 				oss << ", ";

--- a/src/objects/PyObject.cpp
+++ b/src/objects/PyObject.cpp
@@ -95,16 +95,18 @@ namespace PyExt::Remote {
 		ostringstream oss;
 		bool empty = true;
 
-		// repr of built-in base types
-		for (auto const& typeObj : type().mro()->listValue()) {
-			auto const typeName = PyTypeObject(typeObj->offset()).name();
-			auto const& types = PyTypeObject::builtinTypes;
-			if (find(types.begin(), types.end(), typeName) != types.end()) {
-				if (!empty)
-					oss << sectionSeparator;
-				else
-					empty = false;
-				oss << typeName << " repr: " << make(offset(), typeName)->repr();
+		// repr of built-in base types (not for built-in types itself)
+		auto const& types = PyTypeObject::builtinTypes;
+		if (find(types.begin(), types.end(), type().name()) == types.end()) {
+			for (auto const& typeObj : type().mro()->listValue()) {
+				auto const typeName = PyTypeObject(typeObj->offset()).name();
+				if (find(types.begin(), types.end(), typeName) != types.end()) {
+					if (!empty)
+						oss << sectionSeparator;
+					else
+						empty = false;
+					oss << typeName << " repr: " << make(offset(), typeName)->repr();
+				}
 			}
 		}
 

--- a/src/objects/PyObject.cpp
+++ b/src/objects/PyObject.cpp
@@ -1,11 +1,13 @@
 #include "PyObject.h"
 
 #include "PyTypeObject.h"
+#include "PyDictObject.h"
 #include "../ExtHelpers.h"
 
 #include <engextcpp.hpp>
 
 #include <string>
+#include <sstream>
 using namespace std;
 
 namespace PyExt::Remote {
@@ -34,9 +36,77 @@ namespace PyExt::Remote {
 	}
 
 
-	auto PyObject::repr(bool /*pretty*/) const -> string
+	auto PyObject::slots() const -> vector<pair<string, unique_ptr<PyObject>>>
 	{
-		return "<" + type().name() + " object>";
+		auto members = type().members();
+		vector<pair<string, unique_ptr<PyObject>>> slots;
+
+		// slots of the type itself and all parents
+		for (auto const& typeObj : type().mro()->listValue()) {
+			auto members = static_cast<PyTypeObject*>(typeObj.get())->members();
+			for (auto const& memberDef : members) {
+				// TODO: handle other types than T_OBJECT_EX
+				if (memberDef->type() == PyMemberDef::T_OBJECT_EX) {
+					auto objPtr = ExtRemoteTyped("(PyObject**)@$extin", offset() + memberDef->offset());
+					auto ptr = objPtr.Dereference().GetPtr();
+					auto value = make(objPtr.Dereference().GetPtr());
+					slots.push_back(make_pair(memberDef->name(), move(value)));
+				}
+			}
+		}
+		return slots;
+	}
+
+
+	auto PyObject::dict() const -> unique_ptr<PyDictObject>
+	{
+		auto dictOffset_ = type().dictOffset();
+		if (dictOffset_ == 0)
+			return nullptr;
+		if (dictOffset_ < 0) {
+			// TODO: offset + size - dictoffset
+			return nullptr;
+		}
+		auto dictPtr = ExtRemoteTyped("(PyDictObject**)@$extin", offset() + dictOffset_);
+		auto dictAddr = dictPtr.Dereference().GetPtr();
+		return make_unique<PyDictObject>(dictAddr);
+	}
+
+
+	auto PyObject::repr(bool pretty) const -> string
+	{
+		string repr = "<" + type().name() + " object>";
+		if (pretty)
+			return utils::link(repr, "!pyobj 0n"s + to_string(offset()));
+		return repr;
+	}
+
+
+	auto PyObject::details() const -> string
+	{
+		const auto elementSeparator = "\n";
+		const auto indentation = "\t";
+		ostringstream oss;
+
+		auto slots_ = slots();
+		if (slots_.size() > 0) {
+			oss << "slots: {" << elementSeparator;
+			for (auto const& pairValue : slots()) {
+				auto const& name = pairValue.first;
+				auto const& value = pairValue.second;
+				oss << indentation << name << ": " << value->repr(true) << ',' << elementSeparator;
+			}
+			oss << '}';
+		}
+
+		auto dictPtr = dict();
+		if (dictPtr != nullptr) {
+			if (slots_.size() > 0)
+				oss << "\n";
+			oss << "dict: " << dictPtr->repr(true);
+		}
+
+		return oss.str();
 	}
 
 

--- a/src/objects/PyObject.cpp
+++ b/src/objects/PyObject.cpp
@@ -70,7 +70,8 @@ namespace PyExt::Remote {
 				obSize = -obSize;
 			dictOffset_ += type().basicSize() + obSize * type().itemSize();
 			// alignment
-			dictOffset_ = (dictOffset_ + (sizeof(void*) - 1)) & ~(sizeof(void*) - 1);
+			auto ptrSize = utils::getPointerSize();
+			dictOffset_ = (dictOffset_ + (ptrSize - 1)) & ~(ptrSize - 1);
 		}
 		auto dictPtr = ExtRemoteTyped("(PyDictObject**)@$extin", offset() + dictOffset_);
 		auto dictAddr = dictPtr.Dereference().GetPtr();

--- a/src/objects/PyObjectMake.cpp
+++ b/src/objects/PyObjectMake.cpp
@@ -16,6 +16,7 @@
 #include "PyFrameObject.h"
 #include "PyCodeObject.h"
 #include "PyFunctionObject.h"
+#include "PyCellObject.h"
 #include "PyNoneObject.h"
 #include "PyNotImplementedObject.h"
 
@@ -75,6 +76,8 @@ namespace PyExt::Remote {
 			return make_unique<PyCodeObject>(remoteAddress);
 		} else if (typeName == "function") {
 			return make_unique<PyFunctionObject>(remoteAddress);
+		} else if (typeName == "cell") {
+			return make_unique<PyCellObject>(remoteAddress);
 		} else if (typeName == "NoneType") {
 			return make_unique<PyNoneObject>(remoteAddress);
 		} else if (typeName == "NotImplementedType") {

--- a/src/objects/PyObjectMake.cpp
+++ b/src/objects/PyObjectMake.cpp
@@ -31,10 +31,17 @@ namespace PyExt::Remote {
 		const auto typeObj = PyObject(remoteAddress).type();
 		const auto typeName = typeObj.name();
 
+		return make(remoteAddress, typeName);
+	}
+
+
+	auto PyObject::make(PyObject::Offset remoteAddress, const std::string& typeName) -> unique_ptr<PyObject>
+	{
 		// TODO: Turn this into a map to factory functions.
 		if (typeName == "type") {
 			return make_unique<PyTypeObject>(remoteAddress);
 		} else if (typeName == "str") {
+			const auto typeObj = PyObject(remoteAddress).type();
 			if (typeObj.isPython2()) {
 				return make_unique<PyStringObject>(remoteAddress);
 			} else {
@@ -53,6 +60,7 @@ namespace PyExt::Remote {
 		} else if (typeName == "dict") {
 			return make_unique<PyDictObject>(remoteAddress);
 		} else if (typeName == "int") {
+			const auto typeObj = PyObject(remoteAddress).type();
 			if (typeObj.isPython2()) {
 				return make_unique<PyIntObject>(remoteAddress);
 			} else {
@@ -63,6 +71,7 @@ namespace PyExt::Remote {
 		} else if (typeName == "float") {
 			return make_unique<PyFloatObject>(remoteAddress);
 		} else if (typeName == "bool") {
+			const auto typeObj = PyObject(remoteAddress).type();
 			if (typeObj.isPython2()) {
 				return make_unique<PyBoolObject>(remoteAddress);
 			} else {

--- a/src/objects/PyStringObject.cpp
+++ b/src/objects/PyStringObject.cpp
@@ -1,6 +1,7 @@
 #include "PyStringObject.h"
 
 #include "utils/lossless_cast.h"
+#include "../ExtHelpers.h"
 
 #include <engextcpp.hpp>
 
@@ -40,9 +41,10 @@ namespace PyExt::Remote {
 	}
 
 
-	auto PyBaseStringObject::repr(bool /*pretty*/) const -> string
+	auto PyBaseStringObject::repr(bool pretty) const -> string
 	{
-		return "b" + escapeAndQuoteString(stringValue());
+		string repr = "b" + escapeAndQuoteString(stringValue());
+		return pretty ? utils::escapeDml(repr) : repr;
 	}
 
 

--- a/src/objects/PyStringObject.cpp
+++ b/src/objects/PyStringObject.cpp
@@ -43,7 +43,7 @@ namespace PyExt::Remote {
 
 	auto PyBaseStringObject::repr(bool pretty) const -> string
 	{
-		string repr = "b" + escapeAndQuoteString(stringValue());
+		string repr = escapeAndQuoteString(stringValue());
 		return pretty ? utils::escapeDml(repr) : repr;
 	}
 
@@ -52,6 +52,12 @@ namespace PyExt::Remote {
 	PyBytesObject::PyBytesObject(Offset objectAddress)
 		: PyBaseStringObject(objectAddress, "PyBytesObject")
 	{
+	}
+
+
+	auto PyBytesObject::repr(bool pretty) const -> string
+	{
+		return "b" + PyBaseStringObject::repr(pretty);
 	}
 
 

--- a/src/objects/PyTupleObject.cpp
+++ b/src/objects/PyTupleObject.cpp
@@ -50,7 +50,7 @@ namespace PyExt::Remote {
 	}
 
 
-	auto PyTupleObject::repr(bool /*pretty*/) const -> string
+	auto PyTupleObject::repr(bool pretty) const -> string
 	{
 		ostringstream oss;
 		oss << "(";
@@ -59,7 +59,7 @@ namespace PyExt::Remote {
 		for (SSize i = 0; i < count; ++i) {
 			auto elem = at(i);
 			if (elem != nullptr)
-				oss << elem->repr();
+				oss << elem->repr(pretty);
 
 			if (i + 1 < count)
 				oss << ", ";

--- a/src/objects/PyTypeObject.cpp
+++ b/src/objects/PyTypeObject.cpp
@@ -23,6 +23,20 @@ namespace PyExt::Remote {
 	}
 
 
+	auto PyTypeObject::basicSize() const -> SSize
+	{
+		auto basicSize = remoteType().Field("tp_basicsize");
+		return utils::readIntegral<SSize>(basicSize);
+	}
+
+
+	auto PyTypeObject::itemSize() const -> SSize
+	{
+		auto itemSize = remoteType().Field("tp_itemsize");
+		return utils::readIntegral<SSize>(itemSize);
+	}
+
+
 	auto PyTypeObject::documentation() const -> string
 	{
 		ExtBuffer<char> buff;

--- a/src/objects/PyTypeObject.cpp
+++ b/src/objects/PyTypeObject.cpp
@@ -1,5 +1,8 @@
 #include "PyTypeObject.h"
 
+#include "../fieldAsPyObject.h"
+#include "../ExtHelpers.h"
+
 #include <engextcpp.hpp>
 #include <string>
 using namespace std;
@@ -32,6 +35,35 @@ namespace PyExt::Remote {
 	}
 
 
+	auto PyTypeObject::members() const -> vector<unique_ptr<PyMemberDef>>
+	{
+		vector<unique_ptr<PyMemberDef>> members;
+		auto tp_members = remoteType().Field("tp_members");
+		if (tp_members.GetPtr() != 0) {
+			for (int i = 0; ; ++i) {
+				auto elem = tp_members.ArrayElement(i);
+				if (elem.Field("name").GetPtr() == 0)
+					break;
+				members.push_back(make_unique<PyMemberDef>(elem.GetPointerTo().GetPtr()));
+			}
+		}
+		return members;
+	}
+
+
+	auto PyTypeObject::dictOffset() const -> SSize
+	{
+		auto dictOffset = remoteType().Field("tp_dictoffset");
+		return utils::readIntegral<SSize>(dictOffset);
+	}
+
+
+	auto PyTypeObject::mro() const -> unique_ptr<PyTupleObject>
+	{
+		return utils::fieldAsPyObject<PyTupleObject>(remoteType(), "tp_mro");
+	}
+
+
 	// This isn't really the best place for this method, but it's useful for factories to know
 	// which type to construct when a Python3 type differs from a Python 2 type of the same name.
 	auto PyTypeObject::isPython2() const -> bool
@@ -40,9 +72,12 @@ namespace PyExt::Remote {
 	}
 
 
-	auto PyTypeObject::repr(bool /*pretty*/) const -> string
+	auto PyTypeObject::repr(bool pretty) const -> string
 	{
-		return "<class '" + name() + "'>";
+		string repr = "<class '" + name() + "'>";
+		if (pretty)
+			return utils::link(repr, "!pyobj 0n"s + to_string(offset()));
+		return repr;
 	}
 
 }

--- a/src/objects/PyTypeObject.cpp
+++ b/src/objects/PyTypeObject.cpp
@@ -53,7 +53,9 @@ namespace PyExt::Remote {
 	{
 		vector<unique_ptr<PyMemberDef>> members;
 		auto tp_members = remoteType().Field("tp_members");
-		if (tp_members.GetPtr() != 0) {
+		auto ptr = tp_members.GetPtr();
+		if (ptr != 0) {
+			tp_members = ExtRemoteTyped("PyMemberDef", ptr, true);  // necessary for Python 3.8+
 			for (int i = 0; ; ++i) {
 				auto elem = tp_members.ArrayElement(i);
 				if (elem.Field("name").GetPtr() == 0)

--- a/src/objects/PyUnicodeObject.cpp
+++ b/src/objects/PyUnicodeObject.cpp
@@ -178,12 +178,10 @@ namespace PyExt::Remote {
 	}
 
 
-	auto PyUnicodeObject::repr(bool /*pretty*/) const -> string
+	auto PyUnicodeObject::repr(bool pretty) const -> string
 	{
-		if (!isReady())
-			return "<str object not ready>";
-
-		return escapeAndQuoteString(stringValue());
+		string repr = isReady() ? escapeAndQuoteString(stringValue()) : "<str object not ready>";
+		return pretty ? utils::escapeDml(repr) : repr;
 	}
 
 }

--- a/src/pystack.cpp
+++ b/src/pystack.cpp
@@ -43,33 +43,6 @@ namespace {
 	}
 
 
-	auto escapeDml(const string& str) -> string
-	{
-		std::string buffer;
-		buffer.reserve(str.size());
-		for (auto ch : str) {
-			switch (ch) {
-				case '&':  buffer += "&amp;";  break;
-				case '\"': buffer += "&quot;"; break;
-				case '\'': buffer += "&apos;"; break;
-				case '<':  buffer += "&lt;";   break;
-				case '>':  buffer += "&gt;";   break;
-				default:   buffer += ch;       break;
-			}
-		}
-		return buffer;
-	}
-
-	auto link(const string& text, const string& cmd, const string& alt = ""s) -> string
-	{
-		ostringstream oss;
-		oss << "<link cmd=\"" << escapeDml(cmd) << "\"";
-		if (!alt.empty())
-			oss << " alt=\"" << escapeDml(alt) << "\"";
-		oss << ">" << escapeDml(text) << "</link>";
-		return oss.str();
-	}
-
 	auto frameToString(const PyFrameObject& frameObject) -> string
 	{
 		ostringstream oss;
@@ -79,9 +52,9 @@ namespace {
 			throw runtime_error("Warning: PyFrameObject is missing PyCodeObject.");
 
 		auto filename = codeObject->filename();
-		oss << "File \"" << link(filename, ".open " + filename, "Open source code.")
+		oss << "File \"" << utils::link(filename, ".open " + filename, "Open source code.")
 			<< "\", line " << frameObject.currentLineNumber()
-			<< ", in " << link(codeObject->name(), "!pyobj 0n" + to_string(codeObject->offset()), "Inspect PyCodeObject.");
+			<< ", in " << utils::link(codeObject->name(), "!pyobj 0n" + to_string(codeObject->offset()), "Inspect PyCodeObject.");
 
 		return oss.str();
 	}
@@ -91,13 +64,15 @@ namespace {
 	{
 		ostringstream oss;
 
+		oss << utils::link("[Frame]", "!pyobj 0n"s + to_string(frameObject.offset()), "Inspect frame object (including localsplus).") << " ";
+
 		auto locals = frameObject.locals();
 		if (locals != nullptr && locals->offset() != 0)
-			oss << link("[Locals]", "!pyobj 0n"s + to_string(locals->offset()), "Inspect this frame's locals.") << " ";
+			oss << utils::link("[Locals]", "!pyobj 0n"s + to_string(locals->offset()), "Inspect this frame's locals.") << " ";
 
 		auto globals = frameObject.globals();
 		if (globals != nullptr && globals->offset() != 0)
-			oss << link("[Globals]", "!pyobj 0n"s + to_string(globals->offset()), "Inspect this frame's captured globals.") << " ";
+			oss << utils::link("[Globals]", "!pyobj 0n"s + to_string(globals->offset()), "Inspect this frame's captured globals.") << " ";
 
 		return oss.str();
 	}

--- a/test/PyExtTest/FibonacciTest.cpp
+++ b/test/PyExtTest/FibonacciTest.cpp
@@ -43,7 +43,7 @@ TEST_CASE("fibonacci_test.py has the expected line numbers.", "[integration][fib
 		std::regex expectedRegex(R"(<code object, file "[^"]*fibonacci_test.py", line \d+>)");
 		REQUIRE(regex_match(codeObj->repr(false), expectedRegex));
 		// Expected to be similar to: "<link cmd="!pyobj 0n140729205561440">&lt;code object, file ".\fibonacci_test.py", line 9&gt;</link>"
-		expectedRegex = R"(<link cmd="!pyobj 0n\d+">&lt;code object, file &quot;[^&]*fibonacci_test.py&quot;, line 9&gt;</link>)";
+		expectedRegex = R"(<link cmd="!pyobj 0n\d+">&lt;code object, file &quot;[^&]*fibonacci_test.py&quot;, line \d+&gt;</link>)";
 		REQUIRE(regex_match(codeObj->repr(true), expectedRegex));
 	}
 

--- a/test/PyExtTest/FibonacciTest.cpp
+++ b/test/PyExtTest/FibonacciTest.cpp
@@ -39,9 +39,11 @@ TEST_CASE("fibonacci_test.py has the expected line numbers.", "[integration][fib
 		REQUIRE(codeObj->name() == "<module>");
 		REQUIRE(codeObj->filename().find("fibonacci_test.py") != std::string::npos);
 
-		// Expected to be similar to: (<code object, file ".\fibonacci_test.py", line 9>)
+		// Expected to be similar to: <code object, file ".\fibonacci_test.py", line 9>
 		std::regex expectedRegex(R"(<code object, file "[^"]*fibonacci_test.py", line \d+>)");
 		REQUIRE(regex_match(codeObj->repr(false), expectedRegex));
+		// Expected to be similar to: "<link cmd="!pyobj 0n140729205561440">&lt;code object, file ".\fibonacci_test.py", line 9&gt;</link>"
+		expectedRegex = R"(<link cmd="!pyobj 0n\d+">&lt;code object, file &quot;[^&]*fibonacci_test.py&quot;, line 9&gt;</link>)";
 		REQUIRE(regex_match(codeObj->repr(true), expectedRegex));
 	}
 

--- a/test/PyExtTest/LocalsplusTest.cpp
+++ b/test/PyExtTest/LocalsplusTest.cpp
@@ -1,0 +1,49 @@
+#include "Catch.hpp"
+
+#include "PythonDumpFile.h"
+#include "TestConfigData.h"
+
+#include <globals.h>
+#include <PyInterpreterState.h>
+#include <PyThreadState.h>
+#include <PyFrameObject.h>
+#include <PyCodeObject.h>
+#include <PyTypeObject.h>
+using namespace PyExt::Remote;
+
+#include <utils/ScopeExit.h>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <iterator>
+#include <regex>
+
+TEST_CASE("localsplus_test.py has the expected frames with localsplus.", "[integration][localsplus_test]")
+{
+	auto dump = PythonDumpFile(TestConfigData::instance().localsplusDumpFileNameOrDefault());
+
+	// Set up pyext.dll so it thinks DbgEng is calling into it.
+	PyExt::InitializeGlobalsForTest(dump.pClient.Get());
+	auto cleanup = utils::makeScopeExit(PyExt::UninitializeGlobalsForTest);
+
+	std::vector<PyFrameObject> frames = dump.getMainThreadFrames();
+	REQUIRE(frames.size() > 3);
+
+	SECTION("Localsplus for frame in methode f().")
+	{
+		auto frameInF = std::find_if(begin(frames), end(frames), [](PyFrameObject& frame) {
+			return frame.code()->name() == "f";
+		});
+
+		std::regex expectedRegex(
+			R"(localsplus: \{\n)"
+			R"(\t'self': <link cmd="!pyobj 0n\d+">&lt;A object&gt;</link>,\n)"
+			R"(\t'a': 'test',\n)"
+			R"(\t'b': \[ 1, 2, 3 \],\n)"
+			R"(\t'c': \{\n)"
+			R"(\t1: 2,\n)"
+			R"(\t3: 4,\n)"
+			R"(\},\n\})");
+		REQUIRE(regex_match(frameInF->details(), expectedRegex));
+	}
+}

--- a/test/PyExtTest/ObjectDetailsTest.cpp
+++ b/test/PyExtTest/ObjectDetailsTest.cpp
@@ -65,7 +65,7 @@ TEST_CASE("object_details.py has a stack frame with expected locals.", "[integra
 			{ "dsubs"        , "DsubS"        , "slots: {\n\tslot1: 1,\n\tslot2: 2,\n}\ndict: {\n\t'd3': 3,\n}" },
 			{ "ssubd"        , "SsubD"        , "slots: {\n\tslot3: 3,\n}\ndict: {\n\t'd1': 1,\n\t'd2': 2,\n}" },
 			{ "ssubds"       , "SsubDS"       , "slots: {\n\tslot3: 5,\n\tslot1: 3,\n\tslot2: 4,\n}\ndict: {\n\t'd1': 1,\n\t'd2': 2,\n}" },
-			{ "negDictOffset", "NegDictOffset", "dict: {\n\t'attr': 'test',\n}" },
+			{ "negDictOffset", "NegDictOffset", "tuple repr: (1, 2, 3)\ndict: {\n\t'attr': 'test',\n}" },
 		};
 		for (auto& objExp : expectations) {
 			auto& name = objExp[0];

--- a/test/PyExtTest/ObjectDetailsTest.cpp
+++ b/test/PyExtTest/ObjectDetailsTest.cpp
@@ -1,0 +1,80 @@
+#include "Catch.hpp"
+
+#include "PythonDumpFile.h"
+#include "TestConfigData.h"
+
+#include <globals.h>
+#include <PyStringValue.h>
+#include <PyFrameObject.h>
+#include <PyCodeObject.h>
+#include <PyTypeObject.h>
+#include <PyDictObject.h>
+using namespace PyExt::Remote;
+
+#include <utils/ScopeExit.h>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <iterator>
+#include <regex>
+using namespace std;
+
+namespace {
+	/// Finds a value in the given dict for a given key.
+	template <typename RangeT>
+	auto findValueByKey(RangeT& pairRange, const string& key) -> PyObject& {
+		auto it = find_if(begin(pairRange), end(pairRange), [&](const auto& keyValuePair) {
+			const auto* keyObj = dynamic_cast<PyStringValue*>(keyValuePair.first.get());
+			return keyObj != nullptr && keyObj->stringValue() == key;
+		});
+
+		if (it == end(pairRange))
+			throw runtime_error("Value not found for key=" + key);
+		return *it->second;
+	}
+}
+
+
+TEST_CASE("object_details.py has a stack frame with expected locals.", "[integration][object_details]")
+{
+	auto dump = PythonDumpFile(TestConfigData::instance().objectDetailsDumpFileNameOrDefault());
+
+	// Set up pyext.dll so it thinks DbgEng is calling into it.
+	PyExt::InitializeGlobalsForTest(dump.pClient.Get());
+	auto cleanup = utils::makeScopeExit(PyExt::UninitializeGlobalsForTest);
+
+	vector<PyFrameObject> frames = dump.getMainThreadFrames();
+	auto& bottomFrame = frames.back();
+	REQUIRE(bottomFrame.code()->name() == "<module>");
+
+	auto locals = bottomFrame.locals();
+	REQUIRE(locals != nullptr);
+
+	auto localPairs = locals->pairValues();
+	REQUIRE(localPairs.size() >= 14);
+
+
+	SECTION("Details of objects.")
+	{
+		vector<vector<int>> test { { 1, 2}, {3, 4} };
+		vector<vector<string>> expectations{
+			{ "d"     , "D"     , "dict: {\n\t'd1': 1,\n\t'd2': 2,\n}" },
+			{ "s"     , "S"     , "slots: {\n\tslot1: 1,\n\tslot2: 2,\n}" },
+			{ "dsubd" , "DsubD" , "dict: {\n\t'd1': 1,\n\t'd2': 2,\n\t'd3': 3,\n}" },
+			{ "ssubs" , "SsubS" , "slots: {\n\tslot3: 3,\n\tslot1: 1,\n\tslot2: 2,\n}" },
+			{ "dsubs" , "DsubS" , "slots: {\n\tslot1: 1,\n\tslot2: 2,\n}\ndict: {\n\t'd3': 3,\n}" },
+			{ "ssubd" , "SsubD" , "slots: {\n\tslot3: 3,\n}\ndict: {\n\t'd1': 1,\n\t'd2': 2,\n}" },
+			{ "ssubds", "SsubDS", "slots: {\n\tslot3: 5,\n\tslot1: 3,\n\tslot2: 4,\n}\ndict: {\n\t'd1': 1,\n\t'd2': 2,\n}" },
+		};
+		for (auto& objExp : expectations) {
+			auto& name = objExp[0];
+			auto& expectedType = objExp[1];
+			auto& expectedDetails = objExp[2];
+
+			auto& obj = findValueByKey(localPairs, name);
+			REQUIRE(obj.type().name() == expectedType);
+			REQUIRE(obj.details() == expectedDetails);
+		}
+	}
+
+}

--- a/test/PyExtTest/ObjectDetailsTest.cpp
+++ b/test/PyExtTest/ObjectDetailsTest.cpp
@@ -58,13 +58,14 @@ TEST_CASE("object_details.py has a stack frame with expected locals.", "[integra
 	{
 		vector<vector<int>> test { { 1, 2}, {3, 4} };
 		vector<vector<string>> expectations{
-			{ "d"     , "D"     , "dict: {\n\t'd1': 1,\n\t'd2': 2,\n}" },
-			{ "s"     , "S"     , "slots: {\n\tslot1: 1,\n\tslot2: 2,\n}" },
-			{ "dsubd" , "DsubD" , "dict: {\n\t'd1': 1,\n\t'd2': 2,\n\t'd3': 3,\n}" },
-			{ "ssubs" , "SsubS" , "slots: {\n\tslot3: 3,\n\tslot1: 1,\n\tslot2: 2,\n}" },
-			{ "dsubs" , "DsubS" , "slots: {\n\tslot1: 1,\n\tslot2: 2,\n}\ndict: {\n\t'd3': 3,\n}" },
-			{ "ssubd" , "SsubD" , "slots: {\n\tslot3: 3,\n}\ndict: {\n\t'd1': 1,\n\t'd2': 2,\n}" },
-			{ "ssubds", "SsubDS", "slots: {\n\tslot3: 5,\n\tslot1: 3,\n\tslot2: 4,\n}\ndict: {\n\t'd1': 1,\n\t'd2': 2,\n}" },
+			{ "d"            , "D"            , "dict: {\n\t'd1': 1,\n\t'd2': 2,\n}" },
+			{ "s"            , "S"            , "slots: {\n\tslot1: 1,\n\tslot2: 2,\n}" },
+			{ "dsubd"        , "DsubD"        , "dict: {\n\t'd1': 1,\n\t'd2': 2,\n\t'd3': 3,\n}" },
+			{ "ssubs"        , "SsubS"        , "slots: {\n\tslot3: 3,\n\tslot1: 1,\n\tslot2: 2,\n}" },
+			{ "dsubs"        , "DsubS"        , "slots: {\n\tslot1: 1,\n\tslot2: 2,\n}\ndict: {\n\t'd3': 3,\n}" },
+			{ "ssubd"        , "SsubD"        , "slots: {\n\tslot3: 3,\n}\ndict: {\n\t'd1': 1,\n\t'd2': 2,\n}" },
+			{ "ssubds"       , "SsubDS"       , "slots: {\n\tslot3: 5,\n\tslot1: 3,\n\tslot2: 4,\n}\ndict: {\n\t'd1': 1,\n\t'd2': 2,\n}" },
+			{ "negDictOffset", "NegDictOffset", "dict: {\n\t'attr': 'test',\n}" },
 		};
 		for (auto& objExp : expectations) {
 			auto& name = objExp[0];

--- a/test/PyExtTest/ObjectTypesTest.cpp
+++ b/test/PyExtTest/ObjectTypesTest.cpp
@@ -70,6 +70,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		auto& string_obj = findValueByKey(localPairs, "string_obj");
 		REQUIRE(string_obj.type().name() == "str");
 		REQUIRE(string_obj.repr().find(expectedValue) != string::npos);
+		REQUIRE(string_obj.details() == "");
 
 		auto stringValue = dynamic_cast<PyStringValue&>(string_obj).stringValue();
 		REQUIRE(stringValue == expectedValue);
@@ -85,6 +86,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		auto& big_string_obj = findValueByKey(localPairs, "big_string_obj");
 		REQUIRE(big_string_obj.type().name() == "str");
 		REQUIRE(big_string_obj.repr().find(expectedValue) != string::npos);
+		REQUIRE(big_string_obj.details() == "");
 
 		auto stringValue = dynamic_cast<PyStringValue&>(big_string_obj).stringValue();
 		REQUIRE(stringValue == expectedValue);
@@ -99,6 +101,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		auto typeName = bytes_obj.type().name();
 		REQUIRE((typeName == "str" || typeName == "bytes"));
 		REQUIRE(bytes_obj.repr().find(expectedValue) != string::npos);
+		REQUIRE(bytes_obj.details() == "");
 
 		auto stringValue = dynamic_cast<PyStringValue&>(bytes_obj).stringValue();
 		REQUIRE(stringValue == expectedValue);
@@ -112,6 +115,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		auto& byte_array_object = findValueByKey(localPairs, "byte_array_object");
 		REQUIRE(byte_array_object.type().name() == "bytearray");
 		REQUIRE(byte_array_object.repr() == "bytearray(b'"+ expectedValue + "')");
+		REQUIRE(byte_array_object.details() == "");
 
 		auto stringValue = dynamic_cast<PyStringValue&>(byte_array_object).stringValue();
 		REQUIRE(stringValue == expectedValue);
@@ -125,6 +129,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		auto& int_obj = findValueByKey(localPairs, "int_obj");
 		REQUIRE(int_obj.type().name() == "int");
 		REQUIRE(int_obj.repr() == to_string(expectedValue));
+		REQUIRE(int_obj.details() == "");
 
 		if (dynamic_cast<PyIntObject*>(&int_obj) != nullptr) { //< PyIntObject only applies to Python2.
 			const auto actualValue = dynamic_cast<PyIntObject&>(int_obj).intValue();
@@ -142,6 +147,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		REQUIRE((typeName == "int" || typeName == "long"));
 		REQUIRE(!long_obj.isNegative());
 		REQUIRE(long_obj.repr() == expectedValue);
+		REQUIRE(long_obj.details() == "");
 	}
 
 
@@ -152,6 +158,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		auto& float_obj = dynamic_cast<PyFloatObject&>(findValueByKey(localPairs, "float_obj"));
 		REQUIRE(float_obj.type().name() == "float");
 		REQUIRE(float_obj.repr().find(to_string(expectedValue)) == 0);
+		REQUIRE(float_obj.details() == "");
 
 		// Comparing floats can be error prone. If this fails, it might need some wiggle room in the compare.
 		REQUIRE(float_obj.floatValue() == expectedValue);
@@ -173,6 +180,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		auto c = complex_obj.repr(false);
 		REQUIRE(regex_match(complex_obj.repr(false), expectedRegex));
 		REQUIRE(regex_match(complex_obj.repr(true), expectedRegex));
+		REQUIRE(complex_obj.details() == "");
 	}
 
 
@@ -184,6 +192,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 
 		const auto actualValue = bool_true_obj.repr();
 		REQUIRE((actualValue == "True" || actualValue == "1"));
+		REQUIRE(bool_true_obj.details() == "");
 	}
 
 
@@ -194,6 +203,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 
 		const auto actualValue = bool_false_obj.repr();
 		REQUIRE((actualValue == "False" || actualValue == "0"));
+		REQUIRE(bool_false_obj.details() == "");
 	}
 
 
@@ -202,6 +212,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		auto& none_obj = findValueByKey(localPairs, "none_obj");
 		REQUIRE(none_obj.type().name() == "NoneType");
 		REQUIRE(none_obj.repr() == "None");
+		REQUIRE(none_obj.details() == "");
 	}
 
 
@@ -214,6 +225,8 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		// Expected to be similar to: "<link cmd="!pyobj 0n140729205561440">&lt;class 'dict'&gt;</link>"
 		std::regex expectedRegex(R"(<link cmd="!pyobj 0n\d+">&lt;class 'dict'&gt;</link>)");
 		REQUIRE(regex_match(type_obj.repr(), expectedRegex));
+		expectedRegex = std::regex(R"(dict: \{[^]+\})");
+		REQUIRE(regex_match(type_obj.details(), expectedRegex));
 	}
 
 
@@ -222,6 +235,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		auto& not_implemented_obj = findValueByKey(localPairs, "not_implemented_obj");
 		REQUIRE(not_implemented_obj.type().name() == "NotImplementedType");
 		REQUIRE(not_implemented_obj.repr() == "NotImplemented");
+		REQUIRE(not_implemented_obj.details() == "");
 	}
 
 
@@ -236,6 +250,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		REQUIRE(func_obj.name()->stringValue() == "test_function");
 		REQUIRE(func_obj.code() != nullptr);
 		REQUIRE(func_obj.doc()->repr().find("Some DocString") != string::npos);
+		REQUIRE(func_obj.details() == "");
 
 		auto qualname = func_obj.qualname();
 		if (qualname != nullptr) //< Python2 doesn't have qualified names.
@@ -260,6 +275,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		std::regex expectedRegex(R"(\[\s*b?'TestString123',\s*1,\s*123456789012345678901234567890123456789012345678901234567890,?\s*\])");
 		REQUIRE(regex_match(list_obj.repr(false), expectedRegex));
 		REQUIRE(regex_match(list_obj.repr(true), expectedRegex));
+		REQUIRE(list_obj.details() == "");
 	}
 
 
@@ -280,6 +296,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		std::regex expectedRegex(R"(\(\s*b?'TestString123',\s*1,\s*123456789012345678901234567890123456789012345678901234567890,?\s*\))");
 		REQUIRE(regex_match(tuple_obj.repr(false), expectedRegex));
 		REQUIRE(regex_match(tuple_obj.repr(true), expectedRegex));
+		REQUIRE(tuple_obj.details() == "");
 	}
 
 
@@ -294,6 +311,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		std::regex expectedRegex(R"(\{((b?'TestString123'\s*)|(\d+)|\s*|,)+\})");
 		REQUIRE(regex_match(set_obj.repr(false), expectedRegex));
 		REQUIRE(regex_match(set_obj.repr(true), expectedRegex));
+		REQUIRE(set_obj.details() == "");
 	}
 
 
@@ -310,5 +328,6 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		std::regex expectedRegex(R"(\{((b?'string_obj':\s*b?'TestString123')|(b?'int_obj':\s*\d+)|(b?'long_obj':\s*\d+)|\s*|,)+\})");
 		REQUIRE(regex_match(dict_obj.repr(false), expectedRegex));
 		REQUIRE(regex_match(dict_obj.repr(true), expectedRegex));
+		REQUIRE(dict_obj.details() == "");
 	}
 }

--- a/test/PyExtTest/ObjectTypesTest.cpp
+++ b/test/PyExtTest/ObjectTypesTest.cpp
@@ -210,7 +210,10 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		auto& type_obj = dynamic_cast<PyTypeObject&>(findValueByKey(localPairs, "type_obj"));
 		REQUIRE(type_obj.type().name() == "type");
 		REQUIRE(type_obj.name() == "dict");
-		REQUIRE(type_obj.repr() == "<class 'dict'>");
+		REQUIRE(type_obj.repr(false) == "<class 'dict'>");
+		// Expected to be similar to: "<link cmd="!pyobj 0n140729205561440">&lt;class 'dict'&gt;</link>"
+		std::regex expectedRegex(R"(<link cmd="!pyobj 0n\d+">&lt;class 'dict'&gt;</link>)");
+		REQUIRE(regex_match(type_obj.repr(), expectedRegex));
 	}
 
 
@@ -226,7 +229,10 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 	{
 		auto& func_obj = dynamic_cast<PyFunctionObject&>(findValueByKey(localPairs, "func_obj"));
 		REQUIRE(func_obj.type().name() == "function");
-		REQUIRE(func_obj.repr() == "<function test_function>");
+		REQUIRE(func_obj.repr(false) == "<function test_function>");
+		// Expected to be similar to: "<link cmd="!pyobj 0n140729205561440">&lt;function test_function&gt;</link>"
+		std::regex expectedRegex(R"(<link cmd="!pyobj 0n\d+">&lt;function test_function&gt;</link>)");
+		REQUIRE(regex_match(func_obj.repr(), expectedRegex));
 		REQUIRE(func_obj.name()->stringValue() == "test_function");
 		REQUIRE(func_obj.code() != nullptr);
 		REQUIRE(func_obj.doc()->repr().find("Some DocString") != string::npos);

--- a/test/PyExtTest/ObjectTypesTest.cpp
+++ b/test/PyExtTest/ObjectTypesTest.cpp
@@ -272,7 +272,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		REQUIRE_THROWS(list_obj.at(3));
 
 		// Expected to be similar to: [ 'TestString123', 1, 123456789012345678901234567890123456789012345678901234567890 ]
-		std::regex expectedRegex(R"(\[\s*b?'TestString123',\s*1,\s*123456789012345678901234567890123456789012345678901234567890,?\s*\])");
+		std::regex expectedRegex(R"(\[\s*'TestString123',\s*1,\s*123456789012345678901234567890123456789012345678901234567890,?\s*\])");
 		REQUIRE(regex_match(list_obj.repr(false), expectedRegex));
 		REQUIRE(regex_match(list_obj.repr(true), expectedRegex));
 		REQUIRE(list_obj.details() == "");
@@ -293,7 +293,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		REQUIRE_THROWS(tuple_obj.at(3));
 
 		// Expected to be similar to: ('TestString123', 1, 123456789012345678901234567890123456789012345678901234567890)
-		std::regex expectedRegex(R"(\(\s*b?'TestString123',\s*1,\s*123456789012345678901234567890123456789012345678901234567890,?\s*\))");
+		std::regex expectedRegex(R"(\(\s*'TestString123',\s*1,\s*123456789012345678901234567890123456789012345678901234567890,?\s*\))");
 		REQUIRE(regex_match(tuple_obj.repr(false), expectedRegex));
 		REQUIRE(regex_match(tuple_obj.repr(true), expectedRegex));
 		REQUIRE(tuple_obj.details() == "");
@@ -308,7 +308,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		REQUIRE(set_obj.listValue().size() == 3);
 
 		// Expected to be similar to: {'TestString123', 1, 123456789012345678901234567890123456789012345678901234567890}
-		std::regex expectedRegex(R"(\{((b?'TestString123'\s*)|(\d+)|\s*|,)+\})");
+		std::regex expectedRegex(R"(\{(('TestString123'\s*)|(\d+)|\s*|,)+\})");
 		REQUIRE(regex_match(set_obj.repr(false), expectedRegex));
 		REQUIRE(regex_match(set_obj.repr(true), expectedRegex));
 		REQUIRE(set_obj.details() == "");
@@ -325,7 +325,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		REQUIRE(pairs.size() == 3);
 
 		// Expected to be similar to: { 'string_obj': 'TestString123', 'int_obj' : 1, 'long_obj' : 123456789012345678901234567890123456789012345678901234567890, }
-		std::regex expectedRegex(R"(\{((b?'string_obj':\s*b?'TestString123')|(b?'int_obj':\s*\d+)|(b?'long_obj':\s*\d+)|\s*|,)+\})");
+		std::regex expectedRegex(R"(\{(('string_obj':\s*'TestString123')|('int_obj':\s*\d+)|('long_obj':\s*\d+)|\s*|,)+\})");
 		REQUIRE(regex_match(dict_obj.repr(false), expectedRegex));
 		REQUIRE(regex_match(dict_obj.repr(true), expectedRegex));
 		REQUIRE(dict_obj.details() == "");

--- a/test/PyExtTest/PyExtTest.vcxproj
+++ b/test/PyExtTest/PyExtTest.vcxproj
@@ -22,20 +22,20 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{AE750E22-5A8E-401E-A843-B9D56B09A015}</ProjectGuid>
     <RootNamespace>PyExtTest</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>
     </CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>
     </CharacterSet>
@@ -43,14 +43,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>
     </CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>
     </CharacterSet>
@@ -95,7 +95,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <PreprocessorDefinitions>NOMINMAX</PreprocessorDefinitions>
     </ClCompile>
     <Link>
@@ -199,7 +199,9 @@ IF NOT EXIST symsrv.dll copy "$(FrameworkSdkDir)Debuggers\$(PlatformTarget)\syms
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="FibonacciTest.cpp" />
+    <ClCompile Include="LocalsplusTest.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="ObjectDetailsTest.cpp" />
     <ClCompile Include="ObjectTypesTest.cpp" />
     <ClCompile Include="PythonDumpFile.cpp" />
     <ClCompile Include="ScopeExitTest.cpp" />

--- a/test/PyExtTest/PyExtTest.vcxproj.filters
+++ b/test/PyExtTest/PyExtTest.vcxproj.filters
@@ -33,6 +33,12 @@
     <ClCompile Include="ScopeExitTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ObjectDetailsTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="LocalsplusTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="PythonDumpFile.h">

--- a/test/PyExtTest/TestConfigData.h
+++ b/test/PyExtTest/TestConfigData.h
@@ -18,6 +18,18 @@ struct TestConfigData {
 		return fibonacciDumpFileName.empty() ? "fibonacci_test.dmp" : fibonacciDumpFileName;
 	}
 	
+	std::string objectDetailsDumpFileName;
+	auto objectDetailsDumpFileNameOrDefault() const -> std::string
+	{
+		return objectDetailsDumpFileName.empty() ? "object_details.dmp" : objectDetailsDumpFileName;
+	}
+
+	std::string localsplusDumpFileName;
+	auto localsplusDumpFileNameOrDefault() const -> std::string
+	{
+		return localsplusDumpFileName.empty() ? "localsplus_test.dmp" : localsplusDumpFileName;
+	}
+
 	std::string symbolPath;
 	auto symbolPathOrDefault() const -> std::string
 	{

--- a/test/PyExtTest/main.cpp
+++ b/test/PyExtTest/main.cpp
@@ -37,6 +37,14 @@ int main(int argc, char* argv[])
 		["--fibonacci-dump-file"]
 		("The dump file to run tests fibonacci tests against.");
 
+	cli |= Opt(configData.objectDetailsDumpFileName, "objectDetailsDumpFileName")
+			["--object-details-dump-file"]
+		("The dump file to run tests object - details test against.");
+
+	cli |= Opt(configData.localsplusDumpFileName, "localsplusDumpFileName")
+			["--localsplus-dump-file"]
+		("The dump file to run tests localsplus tests against.");
+
 	cli |= Opt(configData.symbolPath, "symbolPath")
 		["--symbol-path"]
 		("Location to look for Python symbols. (PDB files)");

--- a/test/scripts/localsplus_test.py
+++ b/test/scripts/localsplus_test.py
@@ -20,11 +20,15 @@ class A:
                 x = cell2
                 win32debug.dump_process("localsplus_test.dmp")
 
-            f_freevar()
+            try:
+                f_freevar()
+            except Exception as e:
+                # e is not initialized (null in localsplus) when creating the dump!
+                pass
 
         assert 'cell2' in f_cellfreevar.__code__.co_cellvars
         assert 'cell1' in f_cellfreevar.__code__.co_freevars
-        assert f_cellfreevar.__code__.co_nlocals == 3  # param, local2, f_freevar
+        assert f_cellfreevar.__code__.co_nlocals == 4  # param, local2, f_freevar, e
         f_cellfreevar(7)
 
 

--- a/test/scripts/localsplus_test.py
+++ b/test/scripts/localsplus_test.py
@@ -5,18 +5,31 @@ class A:
     def __init__(self, a):
         self.a = a
 
-    def f(self, a, b):
-        c = {1: 2, 3: 4}
-        win32debug.dump_process("localsplus_test.dmp")
+    def f_cellvar(self, param1, param2):
+        local1 = 5
+        # c is cell variable because it is used in f_cellfreevar
+        cell1 = {1: 2, 3: 4}
 
+        def f_cellfreevar(param):
+            # cell1 is free variable because it is defined outside f_cellfreevar
+            # cell2 is cell variable because it is used in f_freevar
+            cell2 = param + cell1[1]
+            local2 = 6
 
-class B:
-    def __init__(self, b):
-        self.b = b
+            def f_freevar():
+                x = cell2
+                win32debug.dump_process("localsplus_test.dmp")
+
+            f_freevar()
+
+        assert 'cell2' in f_cellfreevar.__code__.co_cellvars
+        assert 'cell1' in f_cellfreevar.__code__.co_freevars
+        assert f_cellfreevar.__code__.co_nlocals == 3  # param, local2, f_freevar
+        f_cellfreevar(7)
 
 
 def main(a):
-    a.f("test", [1,2,3])
+    a.f_cellvar("test", [1,2,3])
 
 
-main(A(B(1)))
+main(A(1))

--- a/test/scripts/localsplus_test.py
+++ b/test/scripts/localsplus_test.py
@@ -1,0 +1,22 @@
+import win32debug, sys, os
+
+
+class A:
+    def __init__(self, a):
+        self.a = a
+
+    def f(self, a, b):
+        c = {1: 2, 3: 4}
+        win32debug.dump_process("localsplus_test.dmp")
+
+
+class B:
+    def __init__(self, b):
+        self.b = b
+
+
+def main(a):
+    a.f("test", [1,2,3])
+
+
+main(A(B(1)))

--- a/test/scripts/localsplus_test.py
+++ b/test/scripts/localsplus_test.py
@@ -1,7 +1,7 @@
 import win32debug, sys, os
 
 
-class A:
+class A(object):
     def __init__(self, a):
         self.a = a
 

--- a/test/scripts/object_details.py
+++ b/test/scripts/object_details.py
@@ -1,0 +1,66 @@
+import win32debug, sys, os
+
+
+class D:
+    """dict"""
+    def __init__(self, d1, d2):
+        self.d1 = d1
+        self.d2 = d2
+
+
+class S:
+    """slots"""
+    __slots__ = 'slot1', 'slot2'
+
+    def __init__(self, s1, s2):
+        self.slot1 = s1
+        self.slot2 = s2
+
+
+class DsubD(D):
+    """dict, parent dict"""
+    def __init__(self, d1, d2, d3):
+        D.__init__(self, d1, d2)
+        self.d3 = d3
+
+
+class SsubS(S):
+    """slots, parent slots"""
+    __slots__ = 'slot3'
+
+    def __init__(self, s1, s2, s3):
+        S.__init__(self, s1, s2)
+        self.slot3 = s3
+
+
+class DsubS(S):
+    def __init__(self, s1, s2, d3):
+        S.__init__(self, s1, s2)
+        self.d3 = d3
+
+
+class SsubD(D):
+    __slots__ = 'slot3'
+
+    def __init__(self, d1, d2, s3):
+        D.__init__(self, d1, d2)
+        self.slot3 = s3
+
+
+class SsubDS(D, S):
+    __slots__ = 'slot3'
+
+    def __init__(self, d1, d2, s1, s2, s3):
+        D.__init__(self, d1, d2)
+        S.__init__(self, s1, s2)
+        self.slot3 = s3
+
+
+d = D(1, 2)
+s = S(1, 2)
+dsubd = DsubD(1, 2, 3)
+ssubs = SsubS(1, 2, 3)
+dsubs = DsubS(1, 2, 3)
+ssubd = SsubD(1, 2, 3)
+ssubds = SsubDS(1, 2, 3, 4, 5)
+win32debug.dump_process("object_details.dmp")

--- a/test/scripts/object_details.py
+++ b/test/scripts/object_details.py
@@ -34,12 +34,14 @@ class SsubS(S):
 
 
 class DsubS(S):
+    """dict, parent slots"""
     def __init__(self, s1, s2, d3):
         S.__init__(self, s1, s2)
         self.d3 = d3
 
 
 class SsubD(D):
+    """slots, parent dict"""
     __slots__ = 'slot3'
 
     def __init__(self, d1, d2, s3):
@@ -48,12 +50,20 @@ class SsubD(D):
 
 
 class SsubDS(D, S):
+    """slots, parents dict and slots"""
     __slots__ = 'slot3'
 
     def __init__(self, d1, d2, s1, s2, s3):
         D.__init__(self, d1, d2)
         S.__init__(self, s1, s2)
         self.slot3 = s3
+
+
+class NegDictOffset(tuple):
+    """inheriting from tuple leads to a negative tp_dictoffset"""
+
+    def __init__(self, tupleValue):
+        self.attr = 'test'
 
 
 d = D(1, 2)
@@ -63,4 +73,5 @@ ssubs = SsubS(1, 2, 3)
 dsubs = DsubS(1, 2, 3)
 ssubd = SsubD(1, 2, 3)
 ssubds = SsubDS(1, 2, 3, 4, 5)
+negDictOffset = NegDictOffset((1, 2, 3))
 win32debug.dump_process("object_details.dmp")

--- a/test/scripts/object_details.py
+++ b/test/scripts/object_details.py
@@ -7,10 +7,13 @@ class D:
         self.d1 = d1
         self.d2 = d2
 
+    def f(self):
+        self.d_uninitialized = 1
+
 
 class S:
     """slots"""
-    __slots__ = 'slot1', 'slot2'
+    __slots__ = 'slot1', 'slot2', 'slot_uninitialized'
 
     def __init__(self, s1, s2):
         self.slot1 = s1

--- a/test/scripts/object_details.py
+++ b/test/scripts/object_details.py
@@ -1,7 +1,7 @@
 import win32debug, sys, os
 
 
-class D:
+class D(object):
     """dict"""
     def __init__(self, d1, d2):
         self.d1 = d1
@@ -11,7 +11,7 @@ class D:
         self.d_uninitialized = 1
 
 
-class S:
+class S(object):
     """slots"""
     __slots__ = 'slot1', 'slot2', 'slot_uninitialized'
 

--- a/test/scripts/object_types.py
+++ b/test/scripts/object_types.py
@@ -2,7 +2,8 @@ import win32debug, sys, os
 
 string_obj = "TestString123"
 big_string_obj = string_obj * 100
-bytes_obj = b"TestBytes123"
+bytes_obj = b"TestBytes123"  # Python 2: str, Python 3: bytes
+unicode_obj = u"TestUnicode"  # Python 2: unicode, Python 3: str
 byte_array_object = bytearray(b'TestBytearray123')
 int_obj = int(1)
 long_obj = 123456789012345678901234567890123456789012345678901234567890

--- a/test/scripts/run_all_tests.py
+++ b/test/scripts/run_all_tests.py
@@ -24,9 +24,11 @@ if __name__ == '__main__':
         print("Creating dump files with python executable:", installation.exec_path, flush=True)
         subprocess.check_call([installation.exec_path, "object_types.py"])
         subprocess.check_call([installation.exec_path, "fibonacci_test.py"])
+        subprocess.check_call([installation.exec_path, "object_details.py"])
+        subprocess.check_call([installation.exec_path, "localsplus_test.py"])
         
         # Run the tests against the dump files.
         py_ext_test_exe = sys.argv[1] if len(sys.argv) > 1 else "../../x64/Debug/PyExtTest.exe"
         num_failed_tests += subprocess.call(py_ext_test_exe)
 
-sys.exit(num_failed_tests)
+    sys.exit(num_failed_tests)


### PR DESCRIPTION
@SeanCline: At first, thank you for the great tool! We have been using it for some years and it really simplifies the analysis of Python dumps a lot!

In the last few weeks, I implemented some enhancements to make it even more comfortable to analyse Python dumps:

1) When using !pyobj, there is a new section "Details" at the end. There, names and values of attributes (slots and dict) of the object are displayed. This is especially useful for objects of user defined classes.

2) When calling repr() with pretty=true, the representation of PyObjects contains a link to the PyObject. This is especially useful for dicts containing objects of user defined classes and thus for investigating an attribute of an object in more detail.

3) When using !pystack, there is a link to each PyFrameObject. In the "details" of the frame, the names and values of localsplus (local, cell and free variables) are displayed.

With these enhancements, it is often sufficient to call !pystack and then just click on links to navigate to the object of interest.

I also wrote some tests for the new features (tested locally with Python 2.7, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8).

Maybe you like the enhancements and want to merge them?