### PR TITLE
Fix line numbers for Python 3.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ This debugger extension provides visualizations for Python objects and stacktrac
 
 The goal of this project is to provide a similar debugging experience in WinDbg/CDB/NTSD as `already exists in GDB <https://wiki.python.org/moin/DebuggingWithGdb>`_.
 
-Currently, the extension is tested against 32bit and 64bit builds of Python versions 2.7, 3.3, 3.4, 3.5, 3.6, 3.7 and 3.8.
+Currently, the extension is tested against 32bit and 64bit builds of Python versions 2.7, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9 and 3.10.
 
 Installation
 ============

--- a/include/PyCodeObject.h
+++ b/include/PyCodeObject.h
@@ -24,11 +24,14 @@ namespace PyExt::Remote {
 		auto cellVars() const->std::vector<std::string>;
 		auto filename() const -> std::string;
 		auto name() const -> std::string;
-		auto lineNumberTable() const -> std::vector<std::uint8_t>;
+		auto lineNumberTableOld() const -> std::vector<std::uint8_t>;
+		auto lineNumberTableNew() const -> std::vector<std::uint8_t>;
 		auto repr(bool pretty = true) const -> std::string override;
 
 	protected:
 		// Helpers.
+		auto lineNumberFromInstructionOffsetOld(int instruction, const std::vector<uint8_t> &lnotab) const -> int;
+		auto lineNumberFromInstructionOffsetNew(int instruction, const std::vector<uint8_t> &lnotab) const -> int;
 		auto readStringTuple(std::string name) const -> std::vector<std::string>;
 	};
 


### PR DESCRIPTION
When executing the unit tests, I noticed that the Fibonacci test failed with Python 3.10 because of wrong line numbers. It seems this is caused by [PEP 626](https://peps.python.org/pep-0626), which introduces a new attribute `co_linetable`. The old `co_lnotab` is only created lazily and might be empty in the dump. I made some changes to fix line numbers for Python 3.10.

Tests are now passing with Python 3.9 and Python 3.10 on my machine.