### PR TITLE
Add support for Python 3.11

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ This debugger extension provides visualizations for Python objects and stacktrac
 
 The goal of this project is to provide a similar debugging experience in WinDbg/CDB/NTSD as `already exists in GDB <https://wiki.python.org/moin/DebuggingWithGdb>`_.
 
-Currently, the extension is tested against 32bit and 64bit builds of Python versions 2.7, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9 and 3.10.
+Currently, the extension is tested against 32bit and 64bit builds of Python versions 2.7, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10 and 3.11.
 
 Installation
 ============

--- a/include/PyCodeObject.h
+++ b/include/PyCodeObject.h
@@ -7,7 +7,7 @@
 
 namespace PyExt::Remote {
 
-	/// Represents a PyFrameObject in the debuggee's address space.
+	/// Represents a PyCodeObject in the debuggee's address space.
 	class PYEXT_PUBLIC PyCodeObject : public PyObject
 	{
 
@@ -19,9 +19,11 @@ namespace PyExt::Remote {
 		auto numberOfLocals() const -> int;
 		auto firstLineNumber() const -> int;
 		auto lineNumberFromInstructionOffset(int instruction) const -> int;
-		auto varNames() const->std::vector<std::string>;
-		auto freeVars() const->std::vector<std::string>;
-		auto cellVars() const->std::vector<std::string>;
+		auto lineNumberFromPrevInstruction(int instruction) const -> int;
+		auto varNames() const -> std::vector<std::string>;
+		auto freeVars() const -> std::vector<std::string>;
+		auto cellVars() const -> std::vector<std::string>;
+		auto localsplusNames() const -> std::vector<std::string>;
 		auto filename() const -> std::string;
 		auto name() const -> std::string;
 		auto lineNumberTableOld() const -> std::vector<std::uint8_t>;
@@ -31,8 +33,10 @@ namespace PyExt::Remote {
 	protected:
 		// Helpers.
 		auto lineNumberFromInstructionOffsetOld(int instruction, const std::vector<uint8_t> &lnotab) const -> int;
-		auto lineNumberFromInstructionOffsetNew(int instruction, const std::vector<uint8_t> &lnotab) const -> int;
+		auto lineNumberFromInstructionOffsetNew(int instruction, const std::vector<uint8_t> &linetable) const -> int;
 		auto readStringTuple(std::string name) const -> std::vector<std::string>;
+		auto readVarint(std::vector<uint8_t>::const_iterator &index) const -> unsigned int;
+		auto readSvarint(std::vector<uint8_t>::const_iterator &index) const -> int;
 	};
 
 }

--- a/include/PyDictKeysObject.h
+++ b/include/PyDictKeysObject.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "RemoteType.h"
+
+namespace PyExt::Remote {
+
+	/// Represents a PyDictKeysObject in the debuggee's address space.
+	class PYEXT_PUBLIC PyDictKeysObject : private RemoteType
+	{
+
+	public: // Construction/Destruction.
+		explicit PyDictKeysObject(Offset objectAddress);
+
+	public: // Members.
+		auto getEntriesTable() -> ExtRemoteTyped;
+		auto getEntriesTableSize() -> RemoteType::SSize;
+		using RemoteType::remoteType;
+
+	};
+}

--- a/include/PyDictObject.h
+++ b/include/PyDictObject.h
@@ -9,15 +9,47 @@
 
 namespace PyExt::Remote {
 
+	class PyDictKeysObject;
+
+	/// Common interface for PyDictObject and PyManagedDict
+	class PYEXT_PUBLIC PyDict
+	{
+
+	public: // Construction/Destruction.
+		virtual ~PyDict();
+
+	public: // Members.
+		virtual auto pairValues() const->std::vector<std::pair<std::unique_ptr<PyObject>, std::unique_ptr<PyObject>>> = 0;
+		virtual auto repr(bool pretty = true) const->std::string;
+
+	};
+
+
+	class PYEXT_PUBLIC PyManagedDict : public PyDict
+	{
+
+	public: // Construction/Destruction.
+		explicit PyManagedDict(RemoteType::Offset keysPtr, RemoteType::Offset valuesPtrPtr);
+
+	public: // Members.
+		auto pairValues() const->std::vector<std::pair<std::unique_ptr<PyObject>, std::unique_ptr<PyObject>>> override;
+
+	private:
+		RemoteType::Offset keysPtr;
+		RemoteType::Offset valuesPtrPtr;
+
+	};
+
+
 	/// Represents a PyDictObject in the debuggee's address space.
-	class PYEXT_PUBLIC PyDictObject : public PyObject
+	class PYEXT_PUBLIC PyDictObject : public PyObject, public PyDict
 	{
 
 	public: // Construction/Destruction.
 		explicit PyDictObject(Offset objectAddress);
 
 	public: // Members.
-		auto pairValues() const -> std::vector<std::pair<std::unique_ptr<PyObject>, std::unique_ptr<PyObject>>>;
+		auto pairValues() const -> std::vector<std::pair<std::unique_ptr<PyObject>, std::unique_ptr<PyObject>>> override;
 		auto repr(bool pretty = true) const -> std::string override;
 
 	};

--- a/include/PyFrame.h
+++ b/include/PyFrame.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "pyextpublic.h"
+
+namespace PyExt::Remote {
+
+	class Offset;
+	class PyDictObject;
+	class PyCodeObject;
+	class PyFunctionObject;
+	class PyObject;
+
+	/// Common interface for PyFrameObject and PyInterpreterFrame
+	class PYEXT_PUBLIC PyFrame
+	{
+	public:
+		virtual ~PyFrame();
+
+	public: // Members of the remote type.
+		virtual auto locals() const -> std::unique_ptr<PyDictObject> = 0;
+		virtual auto localsplus() const -> std::vector<std::pair<std::string, std::unique_ptr<PyObject>>> = 0;
+		virtual auto globals() const -> std::unique_ptr<PyDictObject> = 0;
+		virtual auto builtins() const -> std::unique_ptr<PyDictObject> = 0;
+		virtual auto code() const -> std::unique_ptr<PyCodeObject> = 0;
+		virtual auto previous() const -> std::unique_ptr<PyFrame> = 0;
+		virtual auto currentLineNumber() const -> int = 0;
+		virtual auto details() const -> std::string;
+	};
+
+}

--- a/include/PyFrameObject.h
+++ b/include/PyFrameObject.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "PyFrame.h"
 #include "PyVarObject.h"
 #include <string>
 #include <memory>
@@ -12,22 +13,23 @@ namespace PyExt::Remote {
 	class PyFunctionObject;
 
 	/// Represents a PyFrameObject in the debuggee's address space.
-	class PYEXT_PUBLIC PyFrameObject : public PyVarObject
+	class PYEXT_PUBLIC PyFrameObject : public PyVarObject, public PyFrame
 	{
 
 	public: // Construction/Destruction.
 		explicit PyFrameObject(Offset objectAddress);
 
 	public: // Members.
-		auto locals() const -> std::unique_ptr<PyDictObject>;
-		auto localsplus() const -> std::vector<std::pair<std::string, std::unique_ptr<PyObject>>>;
-		auto globals() const -> std::unique_ptr<PyDictObject>;
-		auto builtins() const -> std::unique_ptr<PyDictObject>;
-		auto code() const -> std::unique_ptr<PyCodeObject>;
+		auto locals() const -> std::unique_ptr<PyDictObject> override;
+		auto localsplus() const -> std::vector<std::pair<std::string, std::unique_ptr<PyObject>>> override;
+		auto globals() const -> std::unique_ptr<PyDictObject> override;
+		auto builtins() const -> std::unique_ptr<PyDictObject> override;
+		auto code() const -> std::unique_ptr<PyCodeObject> override;
+		auto previous() const->std::unique_ptr<PyFrame> override;
 		auto back() const -> std::unique_ptr<PyFrameObject>;
 		auto trace() const -> std::unique_ptr<PyFunctionObject>;
 		auto lastInstruction() const -> int;
-		auto currentLineNumber() const -> int;
+		auto currentLineNumber() const -> int override;
 		auto repr(bool pretty = true) const -> std::string override;
 		auto details() const -> std::string override;
 

--- a/include/PyInterpreterFrame.h
+++ b/include/PyInterpreterFrame.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "PyFrame.h"
+#include "RemoteType.h"
+#include "pyextpublic.h"
+
+#include <memory>
+
+class ExtRemoteTyped;
+
+namespace PyExt::Remote {
+
+	class PyDictObject;
+	class PyCodeObject;
+	class PyFrameObject;
+	class PyFunctionObject;
+	class PyObject;
+
+	/// Python 3.11 and later
+	/// @see https://github.com/python/cpython/blob/master/include/internal/pycore_frame.h
+	class PYEXT_PUBLIC PyInterpreterFrame : public RemoteType, public PyFrame
+	{
+	public:
+		explicit PyInterpreterFrame(const RemoteType& remoteType);
+
+	public: // Members of the remote type.
+		using RemoteType::offset;
+		auto locals() const->std::unique_ptr<PyDictObject> override;
+		auto localsplus() const->std::vector<std::pair<std::string, std::unique_ptr<PyObject>>> override;
+		auto globals() const->std::unique_ptr<PyDictObject> override;
+		auto builtins() const->std::unique_ptr<PyDictObject> override;
+		auto code() const->std::unique_ptr<PyCodeObject> override;
+		auto previous() const->std::unique_ptr<PyFrame> override;
+		auto prevInstruction() const -> int;
+		auto currentLineNumber() const -> int override;
+	};
+
+}

--- a/include/PyMemberDef.h
+++ b/include/PyMemberDef.h
@@ -5,7 +5,7 @@
 
 namespace PyExt::Remote {
 
-	class PYEXT_PUBLIC PyMemberDef : private RemoteType
+	class PYEXT_PUBLIC PyMemberDef
 	{
 
 	public: // Constants.
@@ -31,13 +31,43 @@ namespace PyExt::Remote {
 		static const int T_NONE           = 20;
 
 	public: // Construction/Destruction.
-		explicit PyMemberDef(Offset objectAddress);
-		~PyMemberDef();
+		virtual ~PyMemberDef();
 
 	public: // Members of the remote type.
-		auto name() const -> std::string;
-		auto type() const -> int;
-		auto offset() const -> SSize;
+		virtual auto name() const -> std::string = 0;
+		virtual auto type() const -> int = 0;
+		virtual auto offset() const -> RemoteType::SSize = 0;
+
+	};
+
+
+	class PYEXT_PUBLIC PyMemberDefAuto : private RemoteType, public PyMemberDef
+	{
+
+	public: // Construction/Destruction.
+		explicit PyMemberDefAuto(Offset objectAddress);
+
+	public: // Members of the remote type.
+		auto name() const -> std::string override;
+		auto type() const -> int override;
+		auto offset() const -> SSize override;
+
+	};
+
+
+	class PYEXT_PUBLIC PyMemberDefManual : public PyMemberDef
+	{
+
+	public: // Construction/Destruction.
+		explicit PyMemberDefManual(RemoteType::Offset objectAddress);
+
+	public: // Members of the remote type.
+		auto name() const -> std::string override;
+		auto type() const -> int override;
+		auto offset() const -> RemoteType::SSize override;
+
+	private:
+		RemoteType::Offset objectAddress;
 
 	};
 

--- a/include/PyObject.h
+++ b/include/PyObject.h
@@ -13,7 +13,7 @@ class ExtRemoteTyped;
 namespace PyExt::Remote {
 
 	class PyTypeObject; //< Forward Declaration.
-	class PyDictObject; //< Forward Declaration.
+	class PyDict; //< Forward Declaration.
 
 	/// Represents a PyObject in the debuggee's address space. Base class for all types of PyObject.
 	class PYEXT_PUBLIC PyObject : private RemoteType
@@ -39,7 +39,7 @@ namespace PyExt::Remote {
 		auto refCount() const -> SSize;
 		auto type() const -> PyTypeObject;
 		auto slots() const -> std::vector<std::pair<std::string, std::unique_ptr<PyObject>>>;
-		auto dict() const -> std::unique_ptr<PyDictObject>;
+		auto dict() const -> std::unique_ptr<PyDict>;
 		virtual auto repr(bool pretty = true) const -> std::string;
 		virtual auto details() const -> std::string;
 

--- a/include/PyThreadState.h
+++ b/include/PyThreadState.h
@@ -9,7 +9,22 @@ class ExtRemoteTyped;
 
 namespace PyExt::Remote {
 
+	class PyFrame;
 	class PyFrameObject;
+	class PyInterpreterFrame;
+
+	/// Python 3.11 and later
+	/// @see https://github.com/python/cpython/blob/master/Include/pystate.h
+	class PYEXT_PUBLIC PyCFrame : public RemoteType
+	{
+	public:
+		explicit PyCFrame(const RemoteType& remoteType);
+		~PyCFrame();
+
+	public: // Members of the remote type.
+		auto current_frame() const -> std::unique_ptr<PyInterpreterFrame>;
+		auto previous() const -> std::unique_ptr<PyCFrame>;
+	};
 
 	/// Represents a PyInterpreterState instance in the debuggee's address space.
 	/// @see https://github.com/python/cpython/blob/master/Include/pystate.h
@@ -21,7 +36,8 @@ namespace PyExt::Remote {
 
 	public: // Members of the remote type.
 		auto next() const -> std::unique_ptr<PyThreadState>;
-		auto frame() const ->std::unique_ptr<PyFrameObject>;
+		auto frame() const -> std::unique_ptr<PyFrameObject>;
+		auto cframe() const -> std::unique_ptr<PyCFrame>;
 		auto recursion_depth() const -> long;
 		auto tracing() const -> long;
 		auto use_tracing() const -> long;
@@ -29,7 +45,7 @@ namespace PyExt::Remote {
 
 	public: // Utility functions around the members.
 		/// Returns a range of all the frames in this threadState.
-		auto allFrames() const -> std::vector<PyFrameObject>; //< TODO: Return generator<PyFrameObject>
+		auto allFrames() const -> std::vector<std::shared_ptr<PyFrame>>; //< TODO: Return generator<PyFrame>
 	};
 
 }

--- a/include/PyTypeObject.h
+++ b/include/PyTypeObject.h
@@ -42,6 +42,7 @@ namespace PyExt::Remote {
 		auto itemSize() const->SSize;
 		auto documentation() const -> std::string;
 		auto members() const -> std::vector<std::unique_ptr<PyMemberDef>>;
+		auto isManagedDict() const -> bool;
 		auto dictOffset() const -> SSize;
 		auto mro() const -> std::unique_ptr<PyTupleObject>;
 		auto isPython2() const -> bool;

--- a/src/ExtHelpers.cpp
+++ b/src/ExtHelpers.cpp
@@ -7,11 +7,11 @@ using namespace std;
 
 namespace utils {
 
-	auto getPointerSize() -> uint64_t
+	auto getPointerSize() -> int
 	{
 		string objExpression = "sizeof(void*)"s;
 		ExtRemoteTyped remoteObj(objExpression.c_str());
-		return utils::readIntegral<uint64_t>(remoteObj);
+		return utils::readIntegral<int>(remoteObj);
 	}
 
 

--- a/src/ExtHelpers.h
+++ b/src/ExtHelpers.h
@@ -52,7 +52,7 @@ namespace utils {
 		return buffer;
 	}
 
-	auto getPointerSize() -> std::uint64_t;
+	auto getPointerSize() -> int;
 	auto escapeDml(const std::string& str) -> std::string;
 	auto link(const std::string& text, const std::string& cmd, const std::string& alt = ""s) -> std::string;
 

--- a/src/PyExt.def
+++ b/src/PyExt.def
@@ -13,3 +13,4 @@ EXPORTS
 	pystack
 	pysymfix
 	pysetautointerpreterstate
+	pyinterpreterframe

--- a/src/PyExt.vcxproj
+++ b/src/PyExt.vcxproj
@@ -94,6 +94,7 @@
     <ClCompile Include="extension.cpp" />
     <ClCompile Include="ExtHelpers.cpp" />
     <ClCompile Include="objects\PyCellObject.cpp" />
+    <ClCompile Include="objects\PyDictKeysObject.cpp" />
     <ClCompile Include="objects\PySetObject.cpp" />
     <ClCompile Include="objects\PyStringValue.cpp" />
     <ClCompile Include="objects\PyBoolObject.cpp" />
@@ -120,9 +121,13 @@
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="PyFrame.cpp" />
+    <ClCompile Include="PyInterpreterFrame.cpp" />
     <ClCompile Include="PyInterpreterState.cpp" />
     <ClInclude Include="..\include\PyCellObject.h" />
-    <ClInclude Include="PyInterpreterState.h" />
+    <ClInclude Include="..\include\PyDictKeysObject.h" />
+    <ClInclude Include="..\include\PyFrame.h" />
+    <ClInclude Include="..\include\PyInterpreterFrame.h" />
     <ClInclude Include="..\include\PyMemberDef.h" />
     <ClCompile Include="PyMemberDef.cpp" />
     <ClCompile Include="pysetautointerpreterstate.cpp" />

--- a/src/PyExt.vcxproj.filters
+++ b/src/PyExt.vcxproj.filters
@@ -135,6 +135,15 @@
     <ClCompile Include="pysetautointerpreterstate.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="PyInterpreterFrame.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="PyFrame.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="objects\PyDictKeysObject.cpp">
+      <Filter>Source Files\objects</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="extension.h">
@@ -236,11 +245,17 @@
     <ClInclude Include="..\include\PyCellObject.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="PyInterpreterState.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\include\PyMemberDef.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\PyFrame.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\PyInterpreterFrame.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\PyDictKeysObject.h">
+      <Filter>Header Files\objects</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/PyFrame.cpp
+++ b/src/PyFrame.cpp
@@ -1,0 +1,34 @@
+#include "PyFrame.h"
+
+#include "PyObject.h"
+
+#include <string>
+#include <sstream>
+using namespace std;
+
+namespace PyExt::Remote {
+
+	PyFrame::~PyFrame()
+	{
+	}
+
+
+	auto PyFrame::details() const -> string
+	{
+		const auto elementSeparator = "\n";
+		const auto indentation = "\t";
+
+		ostringstream oss;
+		oss << "localsplus: {" << elementSeparator;
+
+		for (auto const& pairValue : localsplus()) {
+			auto const& key = pairValue.first;
+			auto const& value = pairValue.second;
+			if (value != nullptr)
+				oss << indentation << key << ": " << value->repr(true) << ',' << elementSeparator;
+		}
+
+		oss << '}';
+		return oss.str();
+	}
+}

--- a/src/PyInterpreterFrame.cpp
+++ b/src/PyInterpreterFrame.cpp
@@ -1,0 +1,95 @@
+#include "PyInterpreterFrame.h"
+
+
+#include "PyObject.h"
+#include "PyCodeObject.h"
+#include "PyDictObject.h"
+#include "PyFrameObject.h"
+
+#include "fieldAsPyObject.h"
+#include "ExtHelpers.h"
+
+#include <engextcpp.hpp>
+
+#include <memory>
+using namespace std;
+
+namespace PyExt::Remote {
+
+	PyInterpreterFrame::PyInterpreterFrame(const RemoteType& remoteType)
+		: RemoteType(remoteType)
+	{
+	}
+
+
+	auto PyInterpreterFrame::locals() const -> unique_ptr<PyDictObject>
+	{
+		// Note: The CPython code comments indicate that this isn't always a dict object. In practice, it seems to be.
+		return utils::fieldAsPyObject<PyDictObject>(remoteType(), "f_locals");
+	}
+
+	auto PyInterpreterFrame::localsplus() const -> vector<pair<string, unique_ptr<PyObject>>>
+	{
+		auto codeObject = code();
+		if (codeObject == nullptr)
+			return {};
+
+		vector<string> names = codeObject->localsplusNames();
+		auto numLocalsplus = names.size();
+		if (numLocalsplus == 0)
+			return {};
+
+		auto f_localsplus = remoteType().Field("localsplus");
+		auto pyObjAddrs = readOffsetArray(f_localsplus, numLocalsplus);
+		vector<pair<string, unique_ptr<PyObject>>> localsplus(numLocalsplus);
+		for (size_t i = 0; i < numLocalsplus; ++i) {
+			auto addr = pyObjAddrs.at(i);
+			auto objPtr = addr ? PyObject::make(addr) : nullptr;
+			localsplus[i] = make_pair(names.at(i), move(objPtr));
+		}
+		return localsplus;
+	}
+
+	auto PyInterpreterFrame::globals() const -> unique_ptr<PyDictObject>
+	{
+		return utils::fieldAsPyObject<PyDictObject>(remoteType(), "f_globals");
+	}
+
+
+	auto PyInterpreterFrame::builtins() const -> unique_ptr<PyDictObject>
+	{
+		return utils::fieldAsPyObject<PyDictObject>(remoteType(), "f_builtins");
+	}
+
+
+	auto PyInterpreterFrame::code() const -> unique_ptr<PyCodeObject>
+	{
+		return utils::fieldAsPyObject<PyCodeObject>(remoteType(), "f_code");
+	}
+
+
+	auto PyInterpreterFrame::previous() const -> unique_ptr<PyFrame>
+	{
+		auto previous = remoteType().Field("previous");
+		if (previous.GetPtr() == 0)
+			return { };
+
+		return make_unique<PyInterpreterFrame>(RemoteType(previous));
+	}
+
+
+	auto PyInterpreterFrame::prevInstruction() const -> int
+	{
+		auto prevInstr = remoteType().Field("prev_instr");
+		return utils::readIntegral<int>(prevInstr);
+	}
+
+
+	auto PyInterpreterFrame::currentLineNumber() const -> int
+	{
+		auto codeObject = code();
+
+		// Do a lookup into the code object's line number table (co_linetable).
+		return codeObject->lineNumberFromPrevInstruction(prevInstruction());
+	}
+}

--- a/src/PyThreadState.cpp
+++ b/src/PyThreadState.cpp
@@ -1,5 +1,7 @@
 #include "PyThreadState.h"
+#include "PyFrame.h"
 #include "PyFrameObject.h"
+#include "PyInterpreterFrame.h"
 
 #include "fieldAsPyObject.h"
 #include "ExtHelpers.h"
@@ -10,6 +12,37 @@
 using namespace std;
 
 namespace PyExt::Remote {
+
+	PyCFrame::PyCFrame(const RemoteType& remoteType)
+		: RemoteType(remoteType)
+	{
+	}
+
+
+	PyCFrame::~PyCFrame()
+	{
+	}
+
+
+	auto PyCFrame::current_frame() const -> std::unique_ptr<PyInterpreterFrame>
+	{
+		auto cframe = remoteType().Field("current_frame");
+		if (cframe.GetPtr() == 0)
+			return { };
+
+		return make_unique<PyInterpreterFrame>(RemoteType(cframe));
+	}
+
+
+	auto PyCFrame::previous() const -> std::unique_ptr<PyCFrame>
+	{
+		auto previous = remoteType().Field("previous");
+		if (previous.GetPtr() == 0)
+			return { };
+
+		return make_unique<PyCFrame>(RemoteType(previous));
+	}
+
 
 	PyThreadState::PyThreadState(const RemoteType& remoteType)
 		: RemoteType(remoteType)
@@ -35,6 +68,16 @@ namespace PyExt::Remote {
 	auto PyThreadState::frame() const -> std::unique_ptr<PyFrameObject>
 	{
 		return utils::fieldAsPyObject<PyFrameObject>(remoteType(), "frame");
+	}
+
+
+	auto PyThreadState::cframe() const -> std::unique_ptr<PyCFrame>
+	{
+		auto cframe = remoteType().Field("cframe");
+		if (cframe.GetPtr() == 0)
+			return { };
+
+		return make_unique<PyCFrame>(RemoteType(cframe));
 	}
 
 
@@ -66,11 +109,16 @@ namespace PyExt::Remote {
 	}
 
 
-	auto PyThreadState::allFrames() const -> std::vector<PyFrameObject>
+	auto PyThreadState::allFrames() const -> vector<shared_ptr<PyFrame>>
 	{
-		vector<PyFrameObject> frames;
-		for (auto f = frame(); f != nullptr; f = f->back()) {
-			frames.push_back(*f);
+		vector<shared_ptr<PyFrame>> frames;
+		shared_ptr<PyFrame> f;
+		f = frame();
+		if (f == nullptr) {
+			f = cframe()->current_frame();
+		}
+		for (; f != nullptr; f = f->previous()) {
+			frames.push_back(f);
 		}
 		return frames;
 	}

--- a/src/extension.cpp
+++ b/src/extension.cpp
@@ -3,6 +3,8 @@
 #include "PyObject.h"
 #include "PyVarObject.h"
 #include "PyTypeObject.h"
+#include "PyInterpreterFrame.h"
+#include "RemoteType.h"
 #include "PyInterpreterState.h"
 using namespace PyExt::Remote;
 
@@ -84,6 +86,18 @@ namespace PyExt {
 		auto details = pyObj->details();
 		if (!details.empty())
 			Dml("\tDetails:\n%s\n", details.c_str());
+	}
+
+
+	EXT_COMMAND(pyinterpreterframe, "Prints information about a Python interpreter frame", "{;s;Frame address}")
+	{
+		ensureSymbolsLoaded();
+
+		auto offset = evalOffset(GetUnnamedArgStr(0));
+		auto frame = make_unique<PyInterpreterFrame>(RemoteType(offset, "_PyInterpreterFrame"));
+
+		auto details = frame->details();
+		Dml("\tDetails:\n%s\n", details.c_str());
 	}
 
 

--- a/src/extension.h
+++ b/src/extension.h
@@ -19,6 +19,7 @@ namespace PyExt {
 		EXT_COMMAND_METHOD(pystack);
 		EXT_COMMAND_METHOD(pysymfix);
 		EXT_COMMAND_METHOD(pysetautointerpreterstate);
+		EXT_COMMAND_METHOD(pyinterpreterframe);
 
 	public: // Known structs.
 		auto KnownStructObjectHandler(_In_ PCSTR TypeName, _In_ ULONG Flags, _In_ ULONG64 Offset) -> void;

--- a/src/objects/PyDictKeysObject.cpp
+++ b/src/objects/PyDictKeysObject.cpp
@@ -1,0 +1,89 @@
+#include "PyDictKeysObject.h"
+
+#include "PyDictObject.h"
+#include "../ExtHelpers.h"
+
+
+namespace PyExt::Remote {
+
+	// We use "_dictkeysobject" because "PyDictKeysObject" is not available in Python < 3.11
+	PyDictKeysObject::PyDictKeysObject(Offset objectAddress)
+		: RemoteType(objectAddress, "_dictkeysobject")
+	{
+	}
+
+
+	auto PyDictKeysObject::getEntriesTable() -> ExtRemoteTyped
+	{
+		auto obj = remoteType();
+
+		// Python <= 3.5 stores a pointer to the entries table in `ma_keys->dk_entries`.
+		if (obj.HasField("dk_entries"))
+			return obj.Field("dk_entries");
+
+		// Python >= 3.6 uses a "compact" layout where the entries appear after the `ma_keys->dk_indices` table.
+		PyObject::SSize size;
+		if (obj.HasField("dk_size")) {
+			auto sizeField = obj.Field("dk_size");
+			size = utils::readIntegral<PyObject::SSize>(sizeField);
+		}
+		else {
+			// Python >= 3.11 stores log2 of size
+			auto log2sizeField = obj.Field("dk_log2_size");
+			auto log2size = utils::readIntegral<uint8_t>(log2sizeField);
+			size = static_cast<PyObject::SSize>(1) << log2size;
+		}
+		auto pointerSize = utils::getPointerSize();
+
+		int indexSize = 0;
+		if (size <= 0xff) {
+			indexSize = 1;
+		}
+		else if (size <= 0xffff) {
+			indexSize = 2;
+		}
+		else if (size <= 0xffffffff) {
+			indexSize = 4;
+		}
+		else {
+			indexSize = pointerSize;
+		}
+
+		auto indicies = obj.Field("dk_indices"); // 3.6 and 3.7 both have an indicies field.
+		ExtRemoteTyped indiciesPtr;
+		if (indicies.HasField("as_1")) {
+			// Python 3.6 accesses dk_indicies though a union.
+			indiciesPtr = indicies.Field("as_1").GetPointerTo();
+		}
+		else {
+			// Python 3.7 accesses it as a char[].
+			indiciesPtr = indicies.GetPointerTo();
+		}
+
+		auto entriesPtr = indiciesPtr.GetPtr() + (size * indexSize);
+		if (obj.HasField("dk_kind")) {  // Python >= 3.11
+			auto dk_kind = obj.Field("dk_kind");
+			auto kind = utils::readIntegral<int>(dk_kind);
+			if (kind != 0)
+				return ExtRemoteTyped("PyDictUnicodeEntry", entriesPtr, true);
+		}
+		return ExtRemoteTyped("PyDictKeyEntry", entriesPtr, true);
+	}
+
+
+	auto PyDictKeysObject::getEntriesTableSize() -> RemoteType::SSize
+	{
+		auto obj = remoteType();
+
+		// Python 3.5
+		if (!obj.HasField("dk_nentries")) {
+			auto sizeField = obj.Field("dk_size");
+			return utils::readIntegral<RemoteType::SSize>(sizeField);
+		}
+
+		// Python >= 3.6
+		auto numEntriesField = obj.Field("dk_nentries");
+		return utils::readIntegral<RemoteType::SSize>(numEntriesField);
+	}
+
+}

--- a/src/objects/PyFrameObject.cpp
+++ b/src/objects/PyFrameObject.cpp
@@ -75,6 +75,12 @@ namespace PyExt::Remote {
 	}
 
 
+	auto PyFrameObject::previous() const -> unique_ptr<PyFrame>
+	{
+		return back();
+	}
+
+
 	auto PyFrameObject::back() const -> unique_ptr<PyFrameObject>
 	{
 		return utils::fieldAsPyObject<PyFrameObject>(remoteType(), "f_back");
@@ -104,7 +110,7 @@ namespace PyExt::Remote {
 			return utils::readIntegral<int>(lineno);
 		}
 
-		// Otherwise, we need to do a lookup into the code object's line number table (co_lnotab).
+		// Otherwise, we need to do a lookup into the code object's line number table (co_linetable resp. co_lnotab).
 		return codeObject->lineNumberFromInstructionOffset(lastInstruction());
 	}
 
@@ -120,21 +126,7 @@ namespace PyExt::Remote {
 
 	auto PyFrameObject::details() const -> string
 	{
-		const auto elementSeparator = "\n";
-		const auto indentation = "\t";
-
-		ostringstream oss;
-		oss << "localsplus: {" << elementSeparator;
-
-		for (auto const& pairValue : localsplus()) {
-			auto const& key = pairValue.first;
-			auto const& value = pairValue.second;
-			if (value != nullptr)
-				oss << indentation << key << ": " << value->repr(true) << ',' << elementSeparator;
-		}
-
-		oss << '}';
-		return oss.str();
+		return PyFrame::details();
 	}
 
 }

--- a/src/pystack.cpp
+++ b/src/pystack.cpp
@@ -1,6 +1,7 @@
 #include "extension.h"
 
 #include "PyFrameObject.h"
+#include "PyInterpreterFrame.h"
 #include "PyDictObject.h"
 #include "PyCodeObject.h"
 #include "PyInterpreterState.h"
@@ -43,34 +44,40 @@ namespace {
 	}
 
 
-	auto frameToString(const PyFrameObject& frameObject) -> string
+	auto frameToString(const PyFrame& frame) -> string
 	{
 		ostringstream oss;
 
-		auto codeObject = frameObject.code();
+		auto codeObject = frame.code();
 		if (codeObject == nullptr)
 			throw runtime_error("Warning: PyFrameObject is missing PyCodeObject.");
 
 		auto filename = codeObject->filename();
 		oss << "File \"" << utils::link(filename, ".open " + filename, "Open source code.")
-			<< "\", line " << frameObject.currentLineNumber()
+			<< "\", line " << frame.currentLineNumber()
 			<< ", in " << utils::link(codeObject->name(), "!pyobj 0n" + to_string(codeObject->offset()), "Inspect PyCodeObject.");
 
 		return oss.str();
 	}
 
 
-	auto frameToCommandString(const PyFrameObject& frameObject) -> string
+	auto frameToCommandString(const PyFrame& frame) -> string
 	{
 		ostringstream oss;
 
-		oss << utils::link("[Frame]", "!pyobj 0n"s + to_string(frameObject.offset()), "Inspect frame object (including localsplus).") << " ";
+		try {
+			auto& interpreterFrame = dynamic_cast<const PyInterpreterFrame&>(frame);
+			oss << utils::link("[Frame]", "!pyinterpreterframe 0n"s + to_string(interpreterFrame.offset()), "Inspect interpreter frame (including localsplus).") << " ";
+		} catch (bad_cast&) {
+			auto& frameObject = dynamic_cast<const PyFrameObject&>(frame);
+			oss << utils::link("[Frame]", "!pyobj 0n"s + to_string(frameObject.offset()), "Inspect frame object (including localsplus).") << " ";
+		}
 
-		auto locals = frameObject.locals();
+		auto locals = frame.locals();
 		if (locals != nullptr && locals->offset() != 0)
 			oss << utils::link("[Locals]", "!pyobj 0n"s + to_string(locals->offset()), "Inspect this frame's locals.") << " ";
 
-		auto globals = frameObject.globals();
+		auto globals = frame.globals();
 		if (globals != nullptr && globals->offset() != 0)
 			oss << utils::link("[Globals]", "!pyobj 0n"s + to_string(globals->offset()), "Inspect this frame's captured globals.") << " ";
 
@@ -86,7 +93,7 @@ namespace PyExt {
 		ensureSymbolsLoaded();
 
 		try {
-			unique_ptr<PyFrameObject> frameObject;
+			unique_ptr<PyFrame> frame;
 
 			// Either start at the user-provided PyFrameObject, or find the top frame of the current thread, if one exists.
 			if (m_NumUnnamedArgs < 1) {
@@ -99,24 +106,30 @@ namespace PyExt {
 				if (!threadState.has_value())
 					throw runtime_error("Thread does not contain any Python frames.");
 
-				frameObject = threadState->frame();
+				frame = threadState->frame();
+
+				if (frame == nullptr) {
+					auto cframe = threadState->cframe();
+					frame = cframe->current_frame();
+				}
+
 			} else {
 				// Print info about the user-provided PyFrameObject as a header.
 				auto frameOffset = evalOffset(GetUnnamedArgStr(0));
 				Out("Stack trace starting at (PyFrameObject*)(%y):\n", frameOffset);
 
-				frameObject = make_unique<PyFrameObject>(frameOffset);
+				frame = make_unique<PyFrameObject>(frameOffset);
 			}
 
-			if (frameObject == nullptr)
-				throw runtime_error("Could not find PyFrameObject.");
+			if (frame == nullptr)
+				throw runtime_error("Could not find PyFrameObject or PyInterpreterFrame.");
 
 			// Print each frame.
-			for (; frameObject != nullptr; frameObject = frameObject->back()) {
-				auto frameStr = frameToString(*frameObject);
+			for (; frame != nullptr; frame = frame->previous()) {
+				auto frameStr = frameToString(*frame);
 				Dml("\t%s\n", frameStr.c_str());
 
-				auto frameCommandStr = frameToCommandString(*frameObject);
+				auto frameCommandStr = frameToCommandString(*frame);
 				Dml("\t\t%s\n", frameCommandStr.c_str());
 			}
 		} catch (exception& ex) {

--- a/test/PyExtTest/FibonacciTest.cpp
+++ b/test/PyExtTest/FibonacciTest.cpp
@@ -25,16 +25,15 @@ TEST_CASE("fibonacci_test.py has the expected line numbers.", "[integration][fib
 	PyExt::InitializeGlobalsForTest(dump.pClient.Get());
 	auto cleanup = utils::makeScopeExit(PyExt::UninitializeGlobalsForTest);
 
-	std::vector<PyFrameObject> frames = dump.getMainThreadFrames();
+	auto frames = dump.getMainThreadFrames();
 	REQUIRE(frames.size() > 90);
 
 	SECTION("Bottom frame is the module.")
 	{
-		auto& bottomFrame = frames.back();
-		REQUIRE(bottomFrame.type().name() == "frame");
-		REQUIRE(bottomFrame.currentLineNumber() == 28);
+		auto bottomFrame = frames.back();
+		REQUIRE(bottomFrame->currentLineNumber() == 28);
 
-		auto codeObj = bottomFrame.code();
+		auto codeObj = bottomFrame->code();
 		REQUIRE(codeObj != nullptr);
 		REQUIRE(codeObj->name() == "<module>");
 		REQUIRE(codeObj->filename().find("fibonacci_test.py") != std::string::npos);
@@ -49,8 +48,8 @@ TEST_CASE("fibonacci_test.py has the expected line numbers.", "[integration][fib
 
 	SECTION("The next several frames are in function recursive_fib.")
 	{
-		auto numFibFrames = std::count_if(begin(frames), end(frames), [](PyFrameObject& frame) {
-			return frame.code()->name() == "recursive_fib" && frame.currentLineNumber() == 24;
+		auto numFibFrames = std::count_if(begin(frames), end(frames), [](auto frame) {
+			return frame->code()->name() == "recursive_fib" && frame->currentLineNumber() == 24;
 		});
 
 		REQUIRE(numFibFrames > 90);
@@ -58,11 +57,11 @@ TEST_CASE("fibonacci_test.py has the expected line numbers.", "[integration][fib
 
 	SECTION("The top frame in recursive_fib is the one that triggered the dump.")
 	{
-		auto topFrameInFib = std::find_if(begin(frames), end(frames), [](PyFrameObject& frame) {
-			return frame.code()->name() == "recursive_fib";
+		auto topFrameInFib = std::find_if(begin(frames), end(frames), [](auto frame) {
+			return frame->code()->name() == "recursive_fib";
 		});
 
-		REQUIRE(topFrameInFib->currentLineNumber() == 18);
-		REQUIRE((topFrameInFib - 1)->code()->name() == "dump_process");
+		REQUIRE((*topFrameInFib)->currentLineNumber() == 18);
+		REQUIRE((*(topFrameInFib - 1))->code()->name() == "dump_process");
 	}
 }

--- a/test/PyExtTest/LocalsplusTest.cpp
+++ b/test/PyExtTest/LocalsplusTest.cpp
@@ -27,7 +27,7 @@ TEST_CASE("localsplus_test.py has the expected frames with localsplus.", "[integ
 	PyExt::InitializeGlobalsForTest(dump.pClient.Get());
 	auto cleanup = utils::makeScopeExit(PyExt::UninitializeGlobalsForTest);
 
-	std::vector<PyFrameObject> frames = dump.getMainThreadFrames();
+	auto frames = dump.getMainThreadFrames();
 	REQUIRE(frames.size() > 6);
 
 	vector<vector<string>> expectations{
@@ -74,13 +74,12 @@ TEST_CASE("localsplus_test.py has the expected frames with localsplus.", "[integ
 
 		SECTION("Localsplus for frame in method " + name + "().")
 		{
-			auto frame = std::find_if(begin(frames), end(frames), [&name](PyFrameObject& frame) {
-				return frame.code()->name() == name;
+			auto frame = std::find_if(begin(frames), end(frames), [&name](auto frame) {
+				return frame->code()->name() == name;
 				});
 
 			std::regex expectedRegex(details);
-			//REQUIRE(frameInF->details() == "test");
-			REQUIRE(regex_match(frame->details(), expectedRegex));
+			REQUIRE(regex_match((*frame)->details(), expectedRegex));
 		}
 	}
 	

--- a/test/PyExtTest/ObjectDetailsTest.cpp
+++ b/test/PyExtTest/ObjectDetailsTest.cpp
@@ -43,11 +43,11 @@ TEST_CASE("object_details.py has a stack frame with expected locals.", "[integra
 	PyExt::InitializeGlobalsForTest(dump.pClient.Get());
 	auto cleanup = utils::makeScopeExit(PyExt::UninitializeGlobalsForTest);
 
-	vector<PyFrameObject> frames = dump.getMainThreadFrames();
-	auto& bottomFrame = frames.back();
-	REQUIRE(bottomFrame.code()->name() == "<module>");
+	auto frames = dump.getMainThreadFrames();
+	auto bottomFrame = frames.back();
+	REQUIRE(bottomFrame->code()->name() == "<module>");
 
-	auto locals = bottomFrame.locals();
+	auto locals = bottomFrame->locals();
 	REQUIRE(locals != nullptr);
 
 	auto localPairs = locals->pairValues();

--- a/test/PyExtTest/ObjectTypesTest.cpp
+++ b/test/PyExtTest/ObjectTypesTest.cpp
@@ -52,11 +52,11 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 	PyExt::InitializeGlobalsForTest(dump.pClient.Get());
 	auto cleanup = utils::makeScopeExit(PyExt::UninitializeGlobalsForTest);
 
-	vector<PyFrameObject> frames = dump.getMainThreadFrames();
-	auto& bottomFrame = frames.back();
-	REQUIRE(bottomFrame.code()->name() == "<module>");
+	auto frames = dump.getMainThreadFrames();
+	auto bottomFrame = frames.back();
+	REQUIRE(bottomFrame->code()->name() == "<module>");
 
-	auto locals = bottomFrame.locals();
+	auto locals = bottomFrame->locals();
 	REQUIRE(locals != nullptr);
 
 	auto localPairs = locals->pairValues();

--- a/test/PyExtTest/PythonDumpFile.cpp
+++ b/test/PyExtTest/PythonDumpFile.cpp
@@ -36,7 +36,7 @@ PythonDumpFile::~PythonDumpFile()
 }
 
 
-auto PythonDumpFile::getMainThreadFrames() const -> std::vector<PyExt::Remote::PyFrameObject>
+auto PythonDumpFile::getMainThreadFrames() const -> std::vector<std::shared_ptr<PyExt::Remote::PyFrame>>
 {
 	auto interpState = PyInterpreterState::makeAutoInterpreterState();
 	auto threads = interpState->allThreadStates();

--- a/test/PyExtTest/PythonDumpFile.h
+++ b/test/PyExtTest/PythonDumpFile.h
@@ -10,7 +10,7 @@ struct IDebugControl;
 struct IDebugSymbols2;
 
 namespace PyExt::Remote {
-	class PyFrameObject;
+	class PyFrame;
 }
 
 class PythonDumpFile {
@@ -20,7 +20,7 @@ public: // Construction/Destruction.
 	~PythonDumpFile();
 
 public:
-	auto getMainThreadFrames() const -> std::vector<PyExt::Remote::PyFrameObject>;
+	auto getMainThreadFrames() const -> std::vector<std::shared_ptr<PyExt::Remote::PyFrame>>;
 
 public: // Debug interfaces.
 	Microsoft::WRL::ComPtr<IDebugClient> pClient;

--- a/test/scripts/run_all_tests.py
+++ b/test/scripts/run_all_tests.py
@@ -28,6 +28,7 @@ if __name__ == '__main__':
         subprocess.check_call([installation.exec_path, "localsplus_test.py"])
         
         # Run the tests against the dump files.
+        print("Running tests with python executable:", installation.exec_path, flush=True)
         py_ext_test_exe = sys.argv[1] if len(sys.argv) > 1 else "../../x64/Debug/PyExtTest.exe"
         num_failed_tests += subprocess.call(py_ext_test_exe)
 


### PR DESCRIPTION
Resolves: #5

Notable changes:
- new class `PyInterpreterFrame` because `PyFrameObject` objects may not be available (in contrast to `PyFrameObject` `PyInterpreterFrame` is not a `PyObject`!)
- new command `!pyinterpreterframe` that is used for the `[Frame]` link (We cannot use `!pyobj` anymore because `PyInterpreterFrame` is not a subclass of `PyObject`)
- format of mapping between instructions and line numbers changed significantly (again), see `PyCodeObject`
- the `__dict__` of Python objects is not stored as `PyDictObject` anymore but as a "managed dict", see `PyObject` and `PyManagedDict`
- new class `PyDictKeysObject` because it is used in `PyDictObject` and `PyManagedDict`
- the symbol `PyMemberDef` is not available (will be available again in 3.12), see `PyTypeObject`, `PyMemberDefAuto` and `PyMemberDefManual`

All tests are passing with Python 3.11 on my machine now.