### PR TITLE
Managed dict fixes

### DIFF
--- a/include/PyDictObject.h
+++ b/include/PyDictObject.h
@@ -29,14 +29,14 @@ namespace PyExt::Remote {
 	{
 
 	public: // Construction/Destruction.
-		explicit PyManagedDict(RemoteType::Offset keysPtr, RemoteType::Offset valuesPtrPtr);
+		explicit PyManagedDict(RemoteType::Offset keysPtr, RemoteType::Offset valuesPtr);
 
 	public: // Members.
 		auto pairValues() const->std::vector<std::pair<std::unique_ptr<PyObject>, std::unique_ptr<PyObject>>> override;
 
 	private:
 		RemoteType::Offset keysPtr;
-		RemoteType::Offset valuesPtrPtr;
+		RemoteType::Offset valuesPtr;
 
 	};
 

--- a/src/objects/PyDictObject.cpp
+++ b/src/objects/PyDictObject.cpp
@@ -87,8 +87,8 @@ namespace PyExt::Remote {
 	}
 
 
-	PyManagedDict::PyManagedDict(RemoteType::Offset keysPtr, RemoteType::Offset valuesPtrPtr)
-		: keysPtr(keysPtr), valuesPtrPtr(valuesPtrPtr)
+	PyManagedDict::PyManagedDict(RemoteType::Offset keysPtr, RemoteType::Offset valuesPtr)
+		: keysPtr(keysPtr), valuesPtr(valuesPtr)
 	{
 	}
 
@@ -100,14 +100,14 @@ namespace PyExt::Remote {
 		auto keys = make_unique<PyDictKeysObject>(keysPtr);
 		auto table = keys->getEntriesTable();
 		auto tableSize = keys->getEntriesTableSize();
-		auto valuesPtr = ExtRemoteTyped("(PyObject***)@$extin", valuesPtrPtr).Dereference().GetPtr();
+		auto nextValue = valuesPtr;
 		auto ptrSize = utils::getPointerSize();
 
-		for (auto i = 0; i < tableSize; ++i, valuesPtr += ptrSize) {
+		for (auto i = 0; i < tableSize; ++i, nextValue += ptrSize) {
 			auto dictEntry = table.ArrayElement(i);
 
 			auto keyPtr = dictEntry.Field("me_key").GetPtr();
-			auto valuePtr = ExtRemoteTyped("(PyObject**)@$extin", valuesPtr).Dereference().GetPtr();
+			auto valuePtr = ExtRemoteTyped("(PyObject**)@$extin", nextValue).Dereference().GetPtr();
 
 			if (keyPtr == 0 || valuePtr == 0) //< The hash bucket might be empty.
 				continue;

--- a/src/objects/PyDictObject.cpp
+++ b/src/objects/PyDictObject.cpp
@@ -103,7 +103,7 @@ namespace PyExt::Remote {
 		auto valuesPtr = ExtRemoteTyped("(PyObject***)@$extin", valuesPtrPtr).Dereference().GetPtr();
 		auto ptrSize = utils::getPointerSize();
 
-		for (auto i = 0; i < tableSize; ++i) {
+		for (auto i = 0; i < tableSize; ++i, valuesPtr += ptrSize) {
 			auto dictEntry = table.ArrayElement(i);
 
 			auto keyPtr = dictEntry.Field("me_key").GetPtr();
@@ -115,7 +115,6 @@ namespace PyExt::Remote {
 			auto key = PyObject::make(keyPtr);
 			auto value = PyObject::make(valuePtr);
 			pairs.push_back(make_pair(move(key), move(value)));
-			valuesPtr += ptrSize;
 		}
 
 		return pairs;

--- a/test/PyExtTest/ObjectDetailsTest.cpp
+++ b/test/PyExtTest/ObjectDetailsTest.cpp
@@ -56,14 +56,15 @@ TEST_CASE("object_details.py has a stack frame with expected locals.", "[integra
 
 	vector<vector<string>> expectations{
 		// Regex only necessary due to Python 2 (dicts not sorted)
-		{ "d"            , "D"            , R"(dict: \{\n\t'(d1': 1,\n\t'd2': 2,|d2': 2,\n\t'd1': 1,)\n\})" },
-		{ "s"            , "S"            , R"(slots: \{\n\tslot1: 1,\n\tslot2: 2,\n\})" },
-		{ "dsubd"        , "DsubD"        , R"(dict: \{\n(\t('d1': 1|'d2': 2|'d3': 3),\n){3}\})" },
-		{ "ssubs"        , "SsubS"        , R"(slots: \{\n\tslot3: 3,\n\tslot1: 1,\n\tslot2: 2,\n\})" },
-		{ "dsubs"        , "DsubS"        , R"(slots: \{\n\tslot1: 1,\n\tslot2: 2,\n\}\ndict: \{\n\t'd3': 3,\n\})" },
-		{ "ssubd"        , "SsubD"        , R"(slots: \{\n\tslot3: 3,\n\}\ndict: \{\n(\t('d1': 1|'d2': 2),\n){2}\})" },
-		{ "ssubds"       , "SsubDS"       , R"(slots: \{\n\tslot3: 5,\n\tslot1: 3,\n\tslot2: 4,\n\}\ndict: \{\n(\t('d1': 1|'d2': 2),\n){2}\})" },
-		{ "negDictOffset", "NegDictOffset", R"(tuple repr: \(1, 2, 3\)\ndict: \{\n\t'attr': 'test',\n\})" },
+		{ "d"            , "D"                  , R"(dict: \{\n\t'(d1': 1,\n\t'd2': 2,|d2': 2,\n\t'd1': 1,)\n\})" },
+		{ "s"            , "S"                  , R"(slots: \{\n\tslot1: 1,\n\tslot2: 2,\n\})" },
+		{ "dsubd"        , "DsubD"              , R"(dict: \{\n(\t('d1': 1|'d2': 2|'d3': 3),\n){3}\})" },
+		{ "ssubs"        , "SsubS"              , R"(slots: \{\n\tslot3: 3,\n\tslot1: 1,\n\tslot2: 2,\n\})" },
+		{ "dsubs"        , "DsubS"              , R"(slots: \{\n\tslot1: 1,\n\tslot2: 2,\n\}\ndict: \{\n\t'd3': 3,\n\})" },
+		{ "ssubd"        , "SsubD"              , R"(slots: \{\n\tslot3: 3,\n\}\ndict: \{\n(\t('d1': 1|'d2': 2),\n){2}\})" },
+		{ "ssubds"       , "SsubDS"             , R"(slots: \{\n\tslot3: 5,\n\tslot1: 3,\n\tslot2: 4,\n\}\ndict: \{\n(\t('d1': 1|'d2': 2),\n){2}\})" },
+		{ "negDictOffset", "NegDictOffset"      , R"(tuple repr: \(1, 2, 3\)\ndict: \{\n\t'attr': 'test',\n\})" },
+		{ "manDictRes"   , "ManagedDictResolved", R"(dict: \{(\n\t'a\d+': \d+,){32}\n\})" },
 	};
 
 	for (auto& objExp : expectations) {

--- a/test/scripts/object_details.py
+++ b/test/scripts/object_details.py
@@ -4,8 +4,10 @@ import win32debug, sys, os
 class D(object):
     """dict"""
     def __init__(self, d1, d2):
+        self.d0 = 0
         self.d1 = d1
         self.d2 = d2
+        del self.d0  # d0 is still in the object's dict but has no value
 
     def f(self):
         self.d_uninitialized = 1

--- a/test/scripts/object_details.py
+++ b/test/scripts/object_details.py
@@ -71,6 +71,20 @@ class NegDictOffset(tuple):
         self.attr = 'test'
 
 
+class ManagedDictResolved(object):
+    """managed dict has two modes:
+    - only values
+    - fully resolved PyDictObject
+
+    We are trying to trigger the second one with this class.
+    """
+    def __init__(self):
+        # Observation: The more attributes an object has, the more likely the dict is not stored
+        # as values only but as PyDictObject, which triggers another branch in the code.
+        for i in range(32):
+            setattr(self, 'a%s' % i, i)
+
+
 d = D(1, 2)
 s = S(1, 2)
 dsubd = DsubD(1, 2, 3)
@@ -79,4 +93,5 @@ dsubs = DsubS(1, 2, 3)
 ssubd = SsubD(1, 2, 3)
 ssubds = SsubDS(1, 2, 3, 4, 5)
 negDictOffset = NegDictOffset((1, 2, 3))
+manDictRes = ManagedDictResolved()
 win32debug.dump_process("object_details.dmp")


### PR DESCRIPTION
While analyzing a dump, I found two errors in handling managed dicts:

- `valuesPtr` was not incremented if we hit the `continue` (first commit)
- `valuesPtr` can be zero; in that case there is already a `PyDictObject` (second commit)