### PR TITLE
Support printing large content

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "stdexcept": "cpp",
+        "string": "cpp"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "files.associations": {
-        "stdexcept": "cpp",
-        "string": "cpp"
-    }
-}

--- a/src/extension.cpp
+++ b/src/extension.cpp
@@ -99,7 +99,7 @@ namespace PyExt {
 
 		auto repr = pyObj->repr(true);
 		if (!repr.empty())
-			printDml("\tRepr: %s\n", repr.c_str());
+			printDml("\tRepr: %s\n", repr);
 
 		auto details = pyObj->details();
 		if (!details.empty())
@@ -115,7 +115,7 @@ namespace PyExt {
 		auto frame = make_unique<PyInterpreterFrame>(RemoteType(offset, "_PyInterpreterFrame"));
 
 		auto details = frame->details();
-		printDml("\tDetails:\n%s\n", details.c_str());
+		printDml("\tDetails:\n%s\n", details);
 	}
 
 

--- a/src/extension.cpp
+++ b/src/extension.cpp
@@ -63,21 +63,20 @@ namespace PyExt {
 	}
 
 
-	auto EXT_CLASS::printDml(const char* format, const string& content) -> void
+	auto EXT_CLASS::printDml(const string& content) -> void
 	{
 		// There is a limit for single output. It seems impossible to know the exact value
 		// of the limit in advance, so we take the value from the documentation.
 		// https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/dbgeng/nf-dbgeng-idebugcontrol4-controlledoutputvalistwide#remarks
 
 		if (content.size() <= chunkSize) {
-			Dml(format, content.c_str());
-			return;
+			Dml("%s", content.c_str());
+		} else {
+			for (size_t chunkOffset = 0; chunkOffset < content.size(); chunkOffset += chunkSize) {
+				Dml("%s", content.substr(chunkOffset, chunkSize).c_str());
+			}
 		}
-
-		for (size_t chunkOffset = 0; chunkOffset < content.size(); chunkOffset += chunkSize) {
-			Dml(format, content.substr(chunkOffset, chunkSize).c_str());
-			format = "%s";
-		}
+		Out("\n");
 	}
 
 
@@ -98,12 +97,16 @@ namespace PyExt {
 			Out("\tSize: %d\n", pyVarObj->size());
 
 		auto repr = pyObj->repr(true);
-		if (!repr.empty())
-			printDml("\tRepr: %s\n", repr);
+		if (!repr.empty()) {
+			Out("\tRepr: ");
+			printDml(repr);
+		}
 
 		auto details = pyObj->details();
-		if (!details.empty())
-			printDml("\tDetails:\n%s\n", details);
+		if (!details.empty()) {
+			Out("\tDetails:\n");
+			printDml(details);
+		}
 	}
 
 
@@ -115,7 +118,8 @@ namespace PyExt {
 		auto frame = make_unique<PyInterpreterFrame>(RemoteType(offset, "_PyInterpreterFrame"));
 
 		auto details = frame->details();
-		printDml("\tDetails:\n%s\n", details);
+		Out("\tDetails:\n");
+		printDml(details);
 	}
 
 

--- a/src/extension.h
+++ b/src/extension.h
@@ -28,7 +28,7 @@ namespace PyExt {
 		static const size_t chunkSize = 16000;
 
 		/// Prints a DML text, splitting it into chunks if needed.
-		auto printDml(const char* format, const std::string& content) -> void;
+		auto printDml(const std::string& content) -> void;
 
 		/// Evaluates an expression as a pointer and returns the result as an offset in the debuggee's address space.
 		auto evalOffset(const std::string& arg) -> UINT64;

--- a/src/extension.h
+++ b/src/extension.h
@@ -25,10 +25,15 @@ namespace PyExt {
 		auto KnownStructObjectHandler(_In_ PCSTR TypeName, _In_ ULONG Flags, _In_ ULONG64 Offset) -> void;
 
 	private: // Helper methods.
+		static const size_t chunkSize = 16000;
+
+		/// Prints a DML text, splitting it into chunks if needed.
+		auto printDml(const char* format, const std::string& content) -> void;
+
 		/// Evaluates an expression as a pointer and returns the result as an offset in the debuggee's address space.
 		auto evalOffset(const std::string& arg) -> UINT64;
 
-		/// Prints an error message to the user  when Python symbols cannot be loaded.
+		/// Prints an error message to the user when Python symbols cannot be loaded.
 		auto ensureSymbolsLoaded() -> void;
 	};
 


### PR DESCRIPTION
Single output is limited to ~16k characters on my machine. This caused a large dict, for example, to not display completely in the console. Moreover, the truncated DML tags broke the output of future commands a bit.