### PR TITLE
Do not call ReadBuffer when there is nothing to read

### DIFF
--- a/src/ExtHelpers.h
+++ b/src/ExtHelpers.h
@@ -35,6 +35,9 @@ namespace utils {
 	template <typename ElemType>
 	auto readArray(/*const*/ ExtRemoteTyped& remoteArray, std::uint64_t numElements) -> std::vector<ElemType>
 	{
+		if (numElements == 0)
+			return { };
+
 		auto remoteData = remoteArray.Dereference();
 		const auto remoteSize = remoteData.GetTypeSize();
 		if (remoteSize != sizeof(ElemType)) {

--- a/src/objects/PyStringObject.cpp
+++ b/src/objects/PyStringObject.cpp
@@ -34,6 +34,9 @@ namespace PyExt::Remote {
 		// String and Bytes objects in Python can embed \0's so we read `len` bytes from the debuggee
 		// instead of stopping at the first \0.
 		const auto len = stringLength();
+		if (len == 0)
+			return ""s;
+
 		string buffer(utils::lossless_cast<size_t>(len), '\0');
 		auto sval = remoteType().Field("ob_sval");
 		sval.Dereference().ReadBuffer(buffer.data(), utils::lossless_cast<ULONG>(buffer.size()));


### PR DESCRIPTION
`ReadBuffer` raises an error when called to read zero-length data:

```
ERROR: !pyobj: extension exception 0x80070057.
    "Zero-sized ExtRemoteData"
```