### PR TITLE
Represent bool stored in long as True/False

### DIFF
--- a/include/PyLongObject.h
+++ b/include/PyLongObject.h
@@ -11,7 +11,7 @@ namespace PyExt::Remote {
 	{
 
 	public: // Construction/Destruction.
-		explicit PyLongObject(Offset objectAddress);
+		explicit PyLongObject(Offset objectAddress, const bool isBool = false);
 
 	public: // Members.
 		auto isNegative() const -> bool;

--- a/include/PyLongObject.h
+++ b/include/PyLongObject.h
@@ -17,6 +17,9 @@ namespace PyExt::Remote {
 		auto isNegative() const -> bool;
 		auto repr(bool pretty = true) const -> std::string override;
 
+	private:
+		const bool isBool;
+
 	};
 
 }

--- a/src/objects/PyLongObject.cpp
+++ b/src/objects/PyLongObject.cpp
@@ -12,8 +12,8 @@ using namespace std;
 
 namespace PyExt::Remote {
 
-	PyLongObject::PyLongObject(Offset objectAddress)
-		: PyVarObject(objectAddress, "PyLongObject")
+	PyLongObject::PyLongObject(Offset objectAddress, const bool isBool)
+		: PyVarObject(objectAddress, "PyLongObject"), isBool(isBool)
 	{
 	}
 
@@ -27,6 +27,12 @@ namespace PyExt::Remote {
 	auto PyLongObject::repr(bool /*pretty*/) const -> string
 	{
 		auto digits = remoteType().Field("ob_digit");
+		if (isBool) {
+			auto digit = digits.ArrayElement(0);
+			const auto value = utils::readIntegral<uint64_t>(digit);
+			return value == 1 ? "True"s : "False"s;
+		}
+
 		const auto bytesPerDigit = digits.ArrayElement(0).GetTypeSize();
 
 		// Set up our constants based on how CPython was compiled.

--- a/src/objects/PyObjectMake.cpp
+++ b/src/objects/PyObjectMake.cpp
@@ -75,7 +75,7 @@ namespace PyExt::Remote {
 			if (typeObj.isPython2()) {
 				return make_unique<PyBoolObject>(remoteAddress);
 			} else {
-				return make_unique<PyLongObject>(remoteAddress);
+				return make_unique<PyLongObject>(remoteAddress, true);
 			}
 		} else if (typeName == "complex") {
 			return make_unique<PyComplexObject>(remoteAddress);

--- a/test/PyExtTest/ObjectTypesTest.cpp
+++ b/test/PyExtTest/ObjectTypesTest.cpp
@@ -191,7 +191,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 
 
 		const auto actualValue = bool_true_obj.repr();
-		REQUIRE((actualValue == "True" || actualValue == "1"));
+		REQUIRE(actualValue == "True");
 		REQUIRE(bool_true_obj.details() == "");
 	}
 
@@ -202,7 +202,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		REQUIRE(bool_false_obj.type().name() == "bool");
 
 		const auto actualValue = bool_false_obj.repr();
-		REQUIRE((actualValue == "False" || actualValue == "0"));
+		REQUIRE(actualValue == "False");
 		REQUIRE(bool_false_obj.details() == "");
 	}
 


### PR DESCRIPTION
Since modern versions of Python store bool as long, its representation is now `1` and `0`. I found it more convenient to see `True` and `False`.