### PR TITLE
Support Python 3.12

### DIFF
--- a/include/PyFrame.h
+++ b/include/PyFrame.h
@@ -20,7 +20,6 @@ namespace PyExt::Remote {
 		virtual auto locals() const -> std::unique_ptr<PyDictObject> = 0;
 		virtual auto localsplus() const -> std::vector<std::pair<std::string, std::unique_ptr<PyObject>>> = 0;
 		virtual auto globals() const -> std::unique_ptr<PyDictObject> = 0;
-		virtual auto builtins() const -> std::unique_ptr<PyDictObject> = 0;
 		virtual auto code() const -> std::unique_ptr<PyCodeObject> = 0;
 		virtual auto previous() const -> std::unique_ptr<PyFrame> = 0;
 		virtual auto currentLineNumber() const -> int = 0;

--- a/include/PyFrameObject.h
+++ b/include/PyFrameObject.h
@@ -23,7 +23,6 @@ namespace PyExt::Remote {
 		auto locals() const -> std::unique_ptr<PyDictObject> override;
 		auto localsplus() const -> std::vector<std::pair<std::string, std::unique_ptr<PyObject>>> override;
 		auto globals() const -> std::unique_ptr<PyDictObject> override;
-		auto builtins() const -> std::unique_ptr<PyDictObject> override;
 		auto code() const -> std::unique_ptr<PyCodeObject> override;
 		auto previous() const->std::unique_ptr<PyFrame> override;
 		auto back() const -> std::unique_ptr<PyFrameObject>;

--- a/include/PyInterpreterFrame.h
+++ b/include/PyInterpreterFrame.h
@@ -28,7 +28,6 @@ namespace PyExt::Remote {
 		auto locals() const->std::unique_ptr<PyDictObject> override;
 		auto localsplus() const->std::vector<std::pair<std::string, std::unique_ptr<PyObject>>> override;
 		auto globals() const->std::unique_ptr<PyDictObject> override;
-		auto builtins() const->std::unique_ptr<PyDictObject> override;
 		auto code() const->std::unique_ptr<PyCodeObject> override;
 		auto previous() const->std::unique_ptr<PyFrame> override;
 		auto prevInstruction() const -> int;

--- a/include/PyInterpreterState.h
+++ b/include/PyInterpreterState.h
@@ -39,9 +39,6 @@ namespace PyExt::Remote {
 	public: // Members of the remote type.
 		auto next() const -> std::unique_ptr<PyInterpreterState>;
 		auto tstate_head() const -> std::unique_ptr<PyThreadState>;
-		auto modules() const -> std::unique_ptr<PyDictObject>;
-		auto sysdict() const -> std::unique_ptr<PyDictObject>;
-		auto builtins() const -> std::unique_ptr<PyDictObject>;
 
 	public: // Utility functions around the members.
 		/// Returns a range of all the threads in this interpreter.

--- a/include/PyLongObject.h
+++ b/include/PyLongObject.h
@@ -1,20 +1,20 @@
 #pragma once
 
-#include "PyVarObject.h"
+#include "PyObject.h"
+
 #include <string>
 #include <cstdint>
 
 namespace PyExt::Remote {
 
 	/// Represents a PyLongObject in the debuggee's address space.
-	class PYEXT_PUBLIC PyLongObject : public PyVarObject
+	class PYEXT_PUBLIC PyLongObject : public PyObject
 	{
 
 	public: // Construction/Destruction.
 		explicit PyLongObject(Offset objectAddress, const bool isBool = false);
 
 	public: // Members.
-		auto isNegative() const -> bool;
 		auto repr(bool pretty = true) const -> std::string override;
 
 	private:

--- a/include/PyThreadState.h
+++ b/include/PyThreadState.h
@@ -38,9 +38,7 @@ namespace PyExt::Remote {
 		auto next() const -> std::unique_ptr<PyThreadState>;
 		auto frame() const -> std::unique_ptr<PyFrameObject>;
 		auto cframe() const -> std::unique_ptr<PyCFrame>;
-		auto recursion_depth() const -> long;
 		auto tracing() const -> long;
-		auto use_tracing() const -> long;
 		auto thread_id() const -> long;
 
 	public: // Utility functions around the members.

--- a/src/ExtHelpers.h
+++ b/src/ExtHelpers.h
@@ -55,6 +55,18 @@ namespace utils {
 		return buffer;
 	}
 
+
+	template<typename T>
+	auto ignoreExtensionError(T&& function) -> void
+	{
+		ExtCaptureOutputA ignoreOut;
+		ignoreOut.Start();
+		try {
+			function();
+		} catch (ExtException&) { }
+	}
+
+
 	auto getPointerSize() -> int;
 	auto escapeDml(const std::string& str) -> std::string;
 	auto link(const std::string& text, const std::string& cmd, const std::string& alt = ""s) -> std::string;

--- a/src/PyInterpreterFrame.cpp
+++ b/src/PyInterpreterFrame.cpp
@@ -56,12 +56,6 @@ namespace PyExt::Remote {
 	}
 
 
-	auto PyInterpreterFrame::builtins() const -> unique_ptr<PyDictObject>
-	{
-		return utils::fieldAsPyObject<PyDictObject>(remoteType(), "f_builtins");
-	}
-
-
 	auto PyInterpreterFrame::code() const -> unique_ptr<PyCodeObject>
 	{
 		return utils::fieldAsPyObject<PyCodeObject>(remoteType(), "f_code");

--- a/src/PyInterpreterFrame.cpp
+++ b/src/PyInterpreterFrame.cpp
@@ -68,6 +68,11 @@ namespace PyExt::Remote {
 		if (previous.GetPtr() == 0)
 			return { };
 
+		auto ownerRaw = previous.Field("owner");
+		auto owner = utils::readIntegral<int8_t>(ownerRaw);
+		if (owner == 3)  // FRAME_OWNED_BY_CSTACK
+			return { };
+
 		return make_unique<PyInterpreterFrame>(RemoteType(previous));
 	}
 

--- a/src/PyInterpreterState.cpp
+++ b/src/PyInterpreterState.cpp
@@ -115,24 +115,6 @@ namespace PyExt::Remote {
 	}
 
 
-	auto PyInterpreterState::modules() const -> std::unique_ptr<PyDictObject>
-	{
-		return utils::fieldAsPyObject<PyDictObject>(remoteType(), "modules");
-	}
-
-
-	auto PyInterpreterState::sysdict() const -> std::unique_ptr<PyDictObject>
-	{
-		return utils::fieldAsPyObject<PyDictObject>(remoteType(), "sysdict");
-	}
-
-
-	auto PyInterpreterState::builtins() const -> std::unique_ptr<PyDictObject>
-	{
-		return utils::fieldAsPyObject<PyDictObject>(remoteType(), "builtins");
-	}
-
-
 	auto PyInterpreterState::allThreadStates() const -> std::vector<PyThreadState>
 	{
 		vector<PyThreadState> states;

--- a/src/PyThreadState.cpp
+++ b/src/PyThreadState.cpp
@@ -81,23 +81,9 @@ namespace PyExt::Remote {
 	}
 
 
-	auto PyThreadState::recursion_depth() const -> long
-	{
-		auto field = remoteType().Field("recursion_depth");
-		return utils::readIntegral<long>(field);
-	}
-
-
 	auto PyThreadState::tracing() const -> long
 	{
 		auto field = remoteType().Field("tracing");
-		return utils::readIntegral<long>(field);
-	}
-
-
-	auto PyThreadState::use_tracing() const -> long
-	{
-		auto field = remoteType().Field("use_tracing");
 		return utils::readIntegral<long>(field);
 	}
 

--- a/src/objects/PyFrameObject.cpp
+++ b/src/objects/PyFrameObject.cpp
@@ -63,12 +63,6 @@ namespace PyExt::Remote {
 	}
 
 
-	auto PyFrameObject::builtins() const -> unique_ptr<PyDictObject>
-	{
-		return utils::fieldAsPyObject<PyDictObject>(remoteType(), "f_builtins");
-	}
-
-
 	auto PyFrameObject::code() const -> unique_ptr<PyCodeObject>
 	{
 		return utils::fieldAsPyObject<PyCodeObject>(remoteType(), "f_code");

--- a/test/PyExtTest/ObjectTypesTest.cpp
+++ b/test/PyExtTest/ObjectTypesTest.cpp
@@ -157,7 +157,7 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		auto& tuple_obj = dynamic_cast<PyTupleObject&>(findValueByKey(localPairs, "all_long_obj"));
 		auto value = tuple_obj.repr(false);
 		std::regex chars_to_remove("[\\s()]+");
-		value = std::regex_replace(repr, chars_to_remove, "");
+		value = std::regex_replace(value, chars_to_remove, "");
 		REQUIRE(value == expectedValue);
 	}
 

--- a/test/PyExtTest/ObjectTypesTest.cpp
+++ b/test/PyExtTest/ObjectTypesTest.cpp
@@ -145,9 +145,20 @@ TEST_CASE("object_types.py has a stack frame with expected locals.", "[integrati
 		auto& long_obj = dynamic_cast<PyLongObject&>(findValueByKey(localPairs, "long_obj"));
 		const auto typeName = long_obj.type().name();
 		REQUIRE((typeName == "int" || typeName == "long"));
-		REQUIRE(!long_obj.isNegative());
 		REQUIRE(long_obj.repr() == expectedValue);
 		REQUIRE(long_obj.details() == "");
+	}
+
+
+	SECTION("Value of all_long_obj.")
+	{
+		const string expectedValue = "0,-123456,123456,987654321987654321987654321,-987654321987654321987654321";
+
+		auto& tuple_obj = dynamic_cast<PyTupleObject&>(findValueByKey(localPairs, "all_long_obj"));
+		auto value = tuple_obj.repr(false);
+		std::regex chars_to_remove("[\\s()]+");
+		value = std::regex_replace(repr, chars_to_remove, "");
+		REQUIRE(value == expectedValue);
 	}
 
 

--- a/test/scripts/object_types.py
+++ b/test/scripts/object_types.py
@@ -7,6 +7,7 @@ unicode_obj = u"TestUnicode"  # Python 2: unicode, Python 3: str
 byte_array_object = bytearray(b'TestBytearray123')
 int_obj = int(1)
 long_obj = 123456789012345678901234567890123456789012345678901234567890
+all_long_obj = (0, -123456, 123456, 987654321987654321987654321, -987654321987654321987654321)
 float_obj = 3.1415
 complex_obj = complex(1.5, -2.25)
 bool_true_obj = True


### PR DESCRIPTION
Key changes:
1. Supported `int` by handling `_PyLongValue` (specifically `PyLongObject` compact mode);
2. Supported `dict` by handling `PyDictOrValues`;
3. Fixed `!pystack` by excluding shim `_PyInterpreterFrame`.

Minor changes:
1. Suppressed symbol not found error for Python 3.11 (`PyMemberDef`);
2. Removed unused code in `PyFrame`-like objects and `PyInterpreterState`.