### PR TITLE
Support Python 3.13 in pystack

### DIFF
--- a/include/PyThreadState.h
+++ b/include/PyThreadState.h
@@ -13,19 +13,6 @@ namespace PyExt::Remote {
 	class PyFrameObject;
 	class PyInterpreterFrame;
 
-	/// Python 3.11 and later
-	/// @see https://github.com/python/cpython/blob/master/Include/pystate.h
-	class PYEXT_PUBLIC PyCFrame : public RemoteType
-	{
-	public:
-		explicit PyCFrame(const RemoteType& remoteType);
-		~PyCFrame();
-
-	public: // Members of the remote type.
-		auto current_frame() const -> std::unique_ptr<PyInterpreterFrame>;
-		auto previous() const -> std::unique_ptr<PyCFrame>;
-	};
-
 	/// Represents a PyInterpreterState instance in the debuggee's address space.
 	/// @see https://github.com/python/cpython/blob/master/Include/pystate.h
 	class PYEXT_PUBLIC PyThreadState : private RemoteType
@@ -36,8 +23,7 @@ namespace PyExt::Remote {
 
 	public: // Members of the remote type.
 		auto next() const -> std::unique_ptr<PyThreadState>;
-		auto frame() const -> std::unique_ptr<PyFrameObject>;
-		auto cframe() const -> std::unique_ptr<PyCFrame>;
+		auto currentFrame() const -> std::unique_ptr<PyFrame>;
 		auto tracing() const -> long;
 		auto thread_id() const -> long;
 

--- a/src/PyInterpreterFrame.cpp
+++ b/src/PyInterpreterFrame.cpp
@@ -58,6 +58,9 @@ namespace PyExt::Remote {
 
 	auto PyInterpreterFrame::code() const -> unique_ptr<PyCodeObject>
 	{
+		auto code = utils::fieldAsPyObject<PyCodeObject>(remoteType(), "f_executable");
+		if (code != nullptr)
+			return code;  // Python 3.13+
 		return utils::fieldAsPyObject<PyCodeObject>(remoteType(), "f_code");
 	}
 
@@ -79,8 +82,10 @@ namespace PyExt::Remote {
 
 	auto PyInterpreterFrame::prevInstruction() const -> int
 	{
-		auto prevInstr = remoteType().Field("prev_instr");
-		return utils::readIntegral<int>(prevInstr);
+		auto instrPtr = remoteType().HasField("instr_ptr")
+			? remoteType().Field("instr_ptr")  // Python 3.13+
+			: remoteType().Field("prev_instr");
+		return utils::readIntegral<int>(instrPtr);
 	}
 
 

--- a/src/pystack.cpp
+++ b/src/pystack.cpp
@@ -108,13 +108,7 @@ namespace PyExt {
 				if (!threadState.has_value())
 					throw runtime_error("Thread does not contain any Python frames.");
 
-				frame = threadState->frame();
-
-				if (frame == nullptr) {
-					auto cframe = threadState->cframe();
-					frame = cframe->current_frame();
-				}
-
+				frame = threadState->currentFrame();
 			} else {
 				// Print info about the user-provided PyFrameObject as a header.
 				auto frameOffset = evalOffset(GetUnnamedArgStr(0));


### PR DESCRIPTION
- Find `PyInterpreterState` and `PyThreadState` fields according to theirs renames and moves in Python 3.13
- Simplified work with frames