### PR TITLE
Support Python 3.13 and make tests for older versions green

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ This debugger extension provides visualizations for Python objects and stacktrac
 
 The goal of this project is to provide a similar debugging experience in WinDbg/CDB/NTSD as `already exists in GDB <https://wiki.python.org/moin/DebuggingWithGdb>`_.
 
-Currently, the extension is tested against 32bit and 64bit builds of Python versions 2.7, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10 and 3.11.
+Currently, the extension is tested against 32bit and 64bit builds of Python versions 2.7, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12 and 3.13.
 
 Installation
 ============

--- a/include/PyFunctionObject.h
+++ b/include/PyFunctionObject.h
@@ -29,7 +29,7 @@ namespace PyExt::Remote {
 		auto closure() const -> std::unique_ptr<PyTupleObject>;
 		auto doc() const -> std::unique_ptr<PyObject>;
 		auto name() const -> std::unique_ptr<PyStringValue>;
-		auto dict() const -> std::unique_ptr<PyDictObject>;
+		auto dict() const -> std::unique_ptr<PyDict> override;
 		auto weakreflist() const -> std::unique_ptr<PyListObject>;
 		auto module() const -> std::unique_ptr<PyObject>;
 		auto annotations() const -> std::unique_ptr<PyDictObject>;

--- a/include/PyObject.h
+++ b/include/PyObject.h
@@ -39,7 +39,8 @@ namespace PyExt::Remote {
 		auto refCount() const -> SSize;
 		auto type() const -> PyTypeObject;
 		auto slots() const -> std::vector<std::pair<std::string, std::unique_ptr<PyObject>>>;
-		auto dict() const -> std::unique_ptr<PyDict>;
+		auto managedDict() const -> std::unique_ptr<PyDict>;
+		virtual auto dict() const -> std::unique_ptr<PyDict>;
 		virtual auto repr(bool pretty = true) const -> std::string;
 		virtual auto details() const -> std::string;
 

--- a/include/PyTypeObject.h
+++ b/include/PyTypeObject.h
@@ -3,6 +3,7 @@
 #include "PyVarObject.h"
 #include "PyMemberDef.h"
 #include "PyTupleObject.h"
+#include "PyDictObject.h"
 #include <array>
 #include <string>
 
@@ -24,9 +25,12 @@ namespace PyExt::Remote {
 		auto documentation() const -> std::string;
 		auto members() const -> std::vector<std::unique_ptr<PyMemberDef>>;
 		auto isManagedDict() const -> bool;
+		auto getStaticBuiltinIndex() const -> SSize;
+		auto hasInlineValues() const -> bool;
 		auto dictOffset() const -> SSize;
 		auto mro() const -> std::unique_ptr<PyTupleObject>;
 		auto isPython2() const -> bool;
+		auto dict() const -> std::unique_ptr<PyDict> override;
 		auto repr(bool pretty = true) const -> std::string override;
 		
 	};

--- a/src/ExtHelpers.cpp
+++ b/src/ExtHelpers.cpp
@@ -43,4 +43,12 @@ namespace utils {
 		return oss.str();
 	}
 
+
+	auto getFullSymbolName(const string& symbolName) -> string
+	{
+		ExtBuffer<char> buffer;
+		g_Ext->FindFirstModule("python???", &buffer, 0);
+		return buffer.GetBuffer() + "!"s + symbolName;
+	}
+
 }

--- a/src/ExtHelpers.h
+++ b/src/ExtHelpers.h
@@ -70,5 +70,6 @@ namespace utils {
 	auto getPointerSize() -> int;
 	auto escapeDml(const std::string& str) -> std::string;
 	auto link(const std::string& text, const std::string& cmd, const std::string& alt = ""s) -> std::string;
+	auto getFullSymbolName(const std::string& symbolName) -> std::string;
 
 }

--- a/src/objects/PyDictObject.cpp
+++ b/src/objects/PyDictObject.cpp
@@ -139,10 +139,12 @@ namespace PyExt::Remote {
 		optional<ExtRemoteTyped> valuesArray;
 		if (!isCombined) {
 			valuesArray = remoteType().Field("ma_values");
-
-			// Since Python 3.11 values are stored in `values` of `ma_values`.
-			if (valuesArray->HasField("values"))
+			utils::ignoreExtensionError([&] {
+				// Python >= 3.11
+				// Find full symbol name because there may be a name collision leading to truncated type info.
+				valuesArray = ExtRemoteTyped(utils::getFullSymbolName("_dictvalues").c_str(), valuesArray->GetPtr(), true);
 				valuesArray = valuesArray->Field("values");
+			});				
 		}
 
 		for (SSize i = 0; i < tableSize; ++i) {

--- a/src/objects/PyFunctionObject.cpp
+++ b/src/objects/PyFunctionObject.cpp
@@ -65,7 +65,7 @@ namespace PyExt::Remote {
 	}
 
 
-	auto PyFunctionObject::dict() const -> unique_ptr<PyDictObject>
+	auto PyFunctionObject::dict() const -> unique_ptr<PyDict>
 	{
 		return utils::fieldAsPyObject<PyDictObject>(remoteType(), "func_dict");
 	}


### PR DESCRIPTION
- Supported version list is updated in README
- `PyTypeObject` now has its own `dict` method implementation as the logic become complex
- Supported inline values in managed dict and `PyManagedDictPointer`
- Added workaround for accessing `_dictvalues->values` (fixes tests)