### PR TITLE
Fix regress with `tp_flags` in Python 2

### DIFF
--- a/src/objects/PyTypeObject.cpp
+++ b/src/objects/PyTypeObject.cpp
@@ -119,6 +119,8 @@ namespace PyExt::Remote {
 
 	auto PyTypeObject::getStaticBuiltinIndex() const -> SSize
 	{
+		if (isPython2())
+			return -1;
 		auto type = remoteType();
 		auto flagsRaw = type.Field("tp_flags");
 		auto flags = utils::readIntegral<unsigned long>(flagsRaw);
@@ -134,6 +136,8 @@ namespace PyExt::Remote {
 
 	auto PyTypeObject::hasInlineValues() const -> bool
 	{
+		if (isPython2())
+			return false;
 		auto flagsRaw = remoteType().Field("tp_flags");
 		auto flags = utils::readIntegral<unsigned long>(flagsRaw);
 		return flags & (1 << 2);  // Py_TPFLAGS_INLINE_VALUES


### PR DESCRIPTION
In #17 there was a regress in Python 2 support due to changes in `PyTypeObject` weren't tested locally. I have now set up tests for 2.7 as well.